### PR TITLE
Handle negative resolution when loading tiff

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -333,11 +333,11 @@ class RGB(_Element, HvRGB):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore')
             da = xr.open_rasterio(filename)
-        return cls.from_tiff(da, crs, apply_transform, **kwargs)
+        return cls.from_xarray(da, crs, apply_transform, **kwargs)
 
 
     @classmethod
-    def from_tiff(cls, da, crs=None, apply_transform=False, **kwargs):
+    def from_xarray(cls, da, crs=None, apply_transform=False, **kwargs):
         """
         Returns an RGB or Image element given an xarray DataArray
         loaded using xr.open_rasterio.

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -371,15 +371,21 @@ class RGB(_Element, HvRGB):
         data = (xs, ys)
         data += tuple(da[b].values for b in range(bands))
 
+        if 'datatype' not in kwargs:
+            kwargs['datatype'] = ['xarray', 'grid', 'image']
+
         if xs.ndim > 1:
             el = QuadMesh if 'crs' in kwargs else HvQuadMesh
-            return el(data, [x, y], **kwargs)
+            el = el(data, [x, y], **kwargs)
         elif bands < 3:
             el = Image if 'crs' in kwargs else HvImage
-            return el(data, [x, y], **kwargs)
-        vdims = cls.vdims[:bands]
-        el = cls if 'crs' in kwargs else HvRGB
-        return el(data, [x, y], vdims, **kwargs)
+            el = el(data, [x, y], **kwargs)
+        else:
+            vdims = cls.vdims[:bands]
+            el = cls if 'crs' in kwargs else HvRGB
+            el = el(data, [x, y], vdims, **kwargs)
+        el.data.attrs = da.attrs
+        return el
 
 
 

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -318,7 +318,7 @@ class RGB(_Element, HvRGB):
     @classmethod
     def load_tiff(cls, filename, crs=None, apply_transform=False, **kwargs):
         """
-        Returns an RGB element or xarray loaded from a geotiff file.
+        Returns an RGB or Image element loaded from a geotiff file.
 
         The data is loaded using xarray and rasterio. If a crs attribute
         is present on the loaded data it will attempt to decode it into
@@ -333,7 +333,19 @@ class RGB(_Element, HvRGB):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore')
             da = xr.open_rasterio(filename)
+        return cls.from_tiff(da, crs, apply_transform, **kwargs)
 
+
+    @classmethod
+    def from_tiff(cls, da, crs=None, apply_transform=False, **kwargs):
+        """
+        Returns an RGB or Image element given an xarray DataArray
+        loaded using xr.open_rasterio.
+
+        If a crs attribute is present on the loaded data it will
+        attempt to decode it into a cartopy projection otherwise it
+        will default to a non-geographic HoloViews element.
+        """
         if crs:
             kwargs['crs'] = crs
         elif hasattr(da, 'crs'):


### PR DESCRIPTION
Ensures that negative resolutions flip the coordinates inside a tiff, ensuring that the image displays with the correct orientation by default.