### PR TITLE
Add iris interface

### DIFF
--- a/geoviews/data/__init__.py
+++ b/geoviews/data/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import param
+from holoviews.core.data import Dataset
 
 try:
     from . import geopandas # noqa (API import)
@@ -8,5 +9,14 @@ except ImportError:
     pass
 except Exception as e:
     param.main.warning('GeoPandas interface failed to import with '
+                       'following error: %s' % e)
+
+try:
+    from . import iris # noqa (API import)
+    Dataset.datatype.append('cube')
+except ImportError:
+    pass
+except Exception as e:
+    param.main.warning('Iris interface failed to import with '
                        'following error: %s' % e)
 

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
+import sys
+
 import numpy as np
-from geopandas import GeoDataFrame
 
 from holoviews.core.data import Interface, MultiInterface, PandasInterface
 from holoviews.core.data.interface  import DataError
@@ -13,14 +14,27 @@ from ..util import geom_to_array
 
 class GeoPandasInterface(MultiInterface):
 
-    types = (GeoDataFrame,)
+    types = ()
 
     datatype = 'geodataframe'
 
     multi = True
 
     @classmethod
+    def loaded(cls):
+        return 'geopandas' in sys.modules
+
+    @classmethod
+    def applies(cls, obj):
+        if not cls.loaded():
+            return False
+        from geopandas import GeoDataFrame
+        return isinstance(obj, GeoDataFrame)
+
+    @classmethod
     def init(cls, eltype, data, kdims, vdims):
+        from geopandas import GeoDataFrame
+
         if not isinstance(data, GeoDataFrame):
             raise ValueError("GeoPandasInterface only support geopandas DataFrames.")
         elif 'geometry' not in data:

--- a/geoviews/data/iris.py
+++ b/geoviews/data/iris.py
@@ -1,0 +1,382 @@
+from __future__ import absolute_import
+
+import sys
+import datetime
+from itertools import product
+
+import numpy as np
+
+from holoviews.core.data.interface import Interface, DataError
+from holoviews.core.data.grid import GridInterface
+from holoviews.core.dimension import Dimension, asdim
+from holoviews.core.element import Element
+from holoviews.core.ndmapping import (NdMapping, item_check, sorted_context)
+from holoviews.core.spaces import HoloMap
+from holoviews.core import util
+
+
+def get_date_format(coord):
+    def date_formatter(val, pos=None):
+        date = coord.units.num2date(val)
+        date_format = Dimension.type_formatters.get(datetime.datetime, None)
+        if date_format:
+            return date.strftime(date_format)
+        else:
+            return date
+
+    return date_formatter
+
+
+def coord_to_dimension(coord):
+    """
+    Converts an iris coordinate to a HoloViews dimension.
+    """
+    kwargs = {}
+    if coord.units.is_time_reference():
+        kwargs['value_format'] = get_date_format(coord)
+    else:
+        kwargs['unit'] = str(coord.units)
+    return Dimension(coord.name(), **kwargs)
+
+
+def sort_coords(coord):
+    """
+    Sorts a list of DimCoords trying to ensure that
+    dates and pressure levels appear first and the
+    longitude and latitude appear last in the correct
+    order.
+    """
+    import iris
+    order = {'T': -2, 'Z': -1, 'X': 1, 'Y': 2}
+    axis = iris.util.guess_coord_axis(coord)
+    return (order.get(axis, 0), coord and coord.name())
+
+
+
+class CubeInterface(GridInterface):
+    """
+    The CubeInterface provides allows HoloViews to interact with iris
+    Cube data. When passing an iris Cube to a HoloViews Element the
+    init method will infer the dimensions of the Cube from its
+    coordinates. Currently the interface only provides the basic
+    methods required for HoloViews to work with an object.
+    """
+
+    types = ()
+
+    datatype = 'cube'
+
+    @classmethod
+    def loaded(cls):
+        return 'iris' in sys.modules
+
+    @classmethod
+    def applies(cls, obj):
+        if not cls.loaded():
+            return False
+        import iris
+        return isinstance(obj, iris.cube.Cube)
+
+    @classmethod
+    def init(cls, eltype, data, kdims, vdims):
+        import iris
+        
+        if kdims:
+            kdims = [asdim(kd) for kd in kdims]
+            kdim_names = [kd.name for kd in kdims]
+        else:
+            kdims = eltype.kdims
+            kdim_names = [kd.name for kd in eltype.kdims]
+
+        if not isinstance(data, iris.cube.Cube):
+            if vdims is None:
+                vdims = eltype.vdims
+            ndims = len(kdim_names)
+            vdim = asdim(vdims[0])
+            vdims = [vdim]
+            if isinstance(data, np.ndarray):
+                if data.ndim != 2 or data.shape[1] != 2 or len(kdims) != 1:
+                    raise ValueError('Iris interface could not interpret array data.')
+                data = {kdims[0].name: data[:, 0], vdim.name: data[:, 1]}
+            elif isinstance(data, tuple):
+                value_array = data[-1]
+                data = {d: vals for d, vals in zip(kdim_names + [vdim.name], data)}
+            elif isinstance(data, list) and data == []:
+                ndims = len(kdims)
+                dimensions = [d.name for d in kdims+vdims]
+                data = {d: np.array([]) for d in dimensions[:ndims]}
+                data.update({d: np.empty((0,) * ndims) for d in dimensions[ndims:]})
+
+            if isinstance(data, dict):
+                value_array = data[vdim.name]
+            coords = [(iris.coords.DimCoord(data[kd.name], long_name=kd.name,
+                                            units=kd.unit), ndims-n-1)
+                      for n, kd in enumerate(kdims)]
+            try:
+                data = iris.cube.Cube(value_array, long_name=vdim.name,
+                                      dim_coords_and_dims=coords)
+            except:
+                pass
+            if not isinstance(data, iris.cube.Cube):
+                raise TypeError('Data must be be an iris Cube type.')
+
+        if kdims:
+            coords = []
+            for kd in kdims:
+                coord = data.coords(kd.name)
+                if len(coord) == 0:
+                    raise ValueError('Key dimension %s not found in '
+                                     'Iris cube.' % kd)
+                coords.append(kd if isinstance(kd, Dimension) else coord[0])
+        else:
+            coords = data.dim_coords
+            coords = sorted(coords, key=sort_coords)
+        kdims = [crd if isinstance(crd, Dimension) else coord_to_dimension(crd)
+                 for crd in coords]
+        if vdims is None:
+            vdims = [Dimension(data.name(), unit=str(data.units))]
+
+        return data, {'kdims':kdims, 'vdims':vdims}, {}
+
+
+    @classmethod
+    def validate(cls, dataset, vdims=True):
+        if vdims and len(dataset.vdims) > 1:
+            raise DataError("Iris cubes do not support more than one value dimension", cls)
+
+
+    @classmethod
+    def irregular(cls, dataset, dim):
+        "CubeInterface does not support irregular data"
+        return False
+
+
+    @classmethod
+    def shape(cls, dataset, gridded=False):
+        if gridded:
+            return dataset.data.shape
+        else:
+            return (cls.length(dataset), len(dataset.dimensions()))
+
+
+    @classmethod
+    def coords(cls, dataset, dim, ordered=False, expanded=False):
+        dim = dataset.get_dimension(dim, strict=True)
+        if expanded:
+            return util.expand_grid_coords(dataset, dim.name)
+        data = dataset.data.coords(dim.name)[0].points
+        if ordered and np.all(data[1:] < data[:-1]):
+            data = data[::-1]
+        return data
+
+
+    @classmethod
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
+        """
+        Returns an array of the values along the supplied dimension.
+        """
+        dim = dataset.get_dimension(dim, strict=True)
+        if dim in dataset.vdims:
+            coord_names = [c.name() for c in dataset.data.dim_coords]
+            data = dataset.data.copy().data
+            data = cls.canonicalize(dataset, data, coord_names)
+            return data.T.flatten() if flat else data
+        elif expanded:
+            data = cls.coords(dataset, dim.name, expanded=True)
+            return data.T.flatten() if flat else data
+        else:
+            return cls.coords(dataset, dim.name, ordered=True)
+
+
+    @classmethod
+    def reindex(cls, dataset, kdims=None, vdims=None):
+        import iris
+        
+        dropped_kdims = [kd for kd in dataset.kdims if kd not in kdims]
+        constant = {}
+        for kd in dropped_kdims:
+            vals = cls.values(dataset, kd.name, expanded=False)
+            if len(vals) == 1:
+                constant[kd.name] = vals[0]
+        if len(constant) == len(dropped_kdims):
+            constraints = iris.Constraint(**constant)
+            return dataset.data.extract(constraints)
+        elif dropped_kdims:
+            return tuple(dataset.columns(kdims+vdims).values())
+        return dataset.data
+
+
+    @classmethod
+    def groupby(cls, dataset, dims, container_type=HoloMap, group_type=None, **kwargs):
+        """
+        Groups the data by one or more dimensions returning a container
+        indexed by the grouped dimensions containing slices of the
+        cube wrapped in the group_type. This makes it very easy to
+        break up a high-dimensional dataset into smaller viewable chunks.
+        """
+        import iris
+
+        if not isinstance(dims, list): dims = [dims]
+        dims = [dataset.get_dimension(d, strict=True) for d in dims]
+        constraints = [d.name for d in dims]
+        slice_dims = [d for d in dataset.kdims if d not in dims]
+
+        # Update the kwargs appropriately for Element group types
+        group_kwargs = {}
+        group_type = dict if group_type == 'raw' else group_type
+        if issubclass(group_type, Element):
+            group_kwargs.update(util.get_param_values(dataset))
+            group_kwargs['kdims'] = slice_dims
+        group_kwargs.update(kwargs)
+
+        drop_dim = any(d not in group_kwargs['kdims'] for d in slice_dims)
+
+        unique_coords = product(*[cls.values(dataset, d, expanded=False)
+                                  for d in dims])
+        data = []
+        for key in unique_coords:
+            constraint = iris.Constraint(**dict(zip(constraints, key)))
+            extracted = dataset.data.extract(constraint)
+            if drop_dim:
+                extracted = group_type(extracted, kdims=slice_dims,
+                                       vdims=dataset.vdims).columns()
+            cube = group_type(extracted, **group_kwargs)
+            data.append((key, cube))
+        if issubclass(container_type, NdMapping):
+            with item_check(False), sorted_context(False):
+                return container_type(data, kdims=dims)
+        else:
+            return container_type(data)
+
+    @classmethod
+    def concat_dim(cls, datasets, dim, vdims):
+        """
+        Concatenates datasets along one dimension
+        """
+        import iris
+        from iris.experimental.equalise_cubes import equalise_attributes
+
+        cubes = []
+        for c, cube in datasets.items():
+            cube = cube.copy()
+            cube.add_aux_coord(iris.coords.DimCoord([c], var_name=dim.name))
+            cubes.append(cube)
+        cubes = iris.cube.CubeList(cubes)
+        equalise_attributes(cubes)
+        return cubes.merge_cube()
+
+
+    @classmethod
+    def range(cls, dataset, dimension):
+        """
+        Computes the range along a particular dimension.
+        """
+        dim = dataset.get_dimension(dimension, strict=True)
+        values = dataset.dimension_values(dim.name, False)
+        return (np.nanmin(values), np.nanmax(values))
+
+
+    @classmethod
+    def redim(cls, dataset, dimensions):
+        """
+        Rename coords on the Cube.
+        """
+        new_dataset = dataset.data.copy()
+        for name, new_dim in dimensions.items():
+            if name == new_dataset.name():
+                new_dataset.rename(new_dim.name)
+            for coord in new_dataset.dim_coords:
+                if name == coord.name():
+                    coord.rename(new_dim.name)
+        return new_dataset
+
+
+    @classmethod
+    def length(cls, dataset):
+        """
+        Returns the total number of samples in the dataset.
+        """
+        return np.product([len(d.points) for d in dataset.data.coords(dim_coords=True)], dtype=np.intp)
+
+
+    @classmethod
+    def sort(cls, columns, by=[], reverse=False):
+        """
+        Cubes are assumed to be sorted by default.
+        """
+        return columns
+
+
+    @classmethod
+    def aggregate(cls, columns, kdims, function, **kwargs):
+        """
+        Aggregation currently not implemented.
+        """
+        raise NotImplementedError
+
+
+    @classmethod
+    def sample(cls, dataset, samples=[]):
+        """
+        Sampling currently not implemented.
+        """
+        raise NotImplementedError
+
+
+    @classmethod
+    def add_dimension(cls, columns, dimension, dim_pos, values, vdim):
+        """
+        Adding value dimensions not currently supported by iris interface.
+        Adding key dimensions not possible on dense interfaces.
+        """
+        if not vdim:
+            raise Exception("Cannot add key dimension to a dense representation.")
+        raise NotImplementedError
+
+
+    @classmethod
+    def select_to_constraint(cls, dataset, selection):
+        """
+        Transform a selection dictionary to an iris Constraint.
+        """
+        import iris
+
+        def get_slicer(start, end):
+            def slicer(cell):
+                return start <= cell.point < end
+            return slicer
+        constraint_kwargs = {}
+        for dim, constraint in selection.items():
+            if isinstance(constraint, slice):
+                constraint = (constraint.start, constraint.stop)
+            if isinstance(constraint, tuple):
+                if constraint == (None, None):
+                    continue
+                constraint = get_slicer(*constraint)
+            dim = dataset.get_dimension(dim, strict=True)
+            constraint_kwargs[dim.name] = constraint
+        return iris.Constraint(**constraint_kwargs)
+
+
+    @classmethod
+    def select(cls, dataset, selection_mask=None, **selection):
+        """
+        Apply a selection to the data.
+        """
+        import iris
+        
+        constraint = cls.select_to_constraint(dataset, selection)
+        pre_dim_coords = [c.name() for c in dataset.data.dim_coords]
+        indexed = cls.indexed(dataset, selection)
+        extracted = dataset.data.extract(constraint)
+        if indexed and not extracted.dim_coords:
+            return extracted.data.item()
+        post_dim_coords = [c.name() for c in extracted.dim_coords]
+        dropped = [c for c in pre_dim_coords if c not in post_dim_coords]
+        for d in dropped:
+            extracted = iris.util.new_axis(extracted, d)
+
+        return extracted
+
+
+Interface.register(CubeInterface)

--- a/geoviews/tests/data/testirisinterface.py
+++ b/geoviews/tests/data/testirisinterface.py
@@ -1,0 +1,266 @@
+from nose.plugins.attrib import attr
+from unittest import SkipTest
+
+import numpy as np
+
+try:
+    import iris
+    from iris.tests.stock import lat_lon_cube
+    from iris.exceptions import MergeError
+except ImportError:
+    raise SkipTest("Could not import iris, skipping IrisInterface tests.")
+
+from holoviews.core.data import Dataset, concat
+from geoviews.data.iris import coord_to_dimension
+from holoviews.core.spaces import HoloMap
+from holoviews.element import Image
+
+from holoviews.tests.core.data.testimageinterface import Image_ImageInterfaceTests
+from holoviews.tests.core.data.testgridinterface import GridInterfaceTests
+
+
+@attr(optional=1)
+class IrisInterfaceTests(GridInterfaceTests):
+    """
+    Tests for Iris interface
+    """
+
+    datatype = 'cube'
+    data_type = iris.cube.Cube
+
+    def init_data(self):
+        self.cube = lat_lon_cube()
+        self.epsilon = 0.01
+
+    def test_concat_grid_3d_shape_mismatch(self):
+        arr1 = np.random.rand(3, 2)
+        arr2 = np.random.rand(2, 3)
+        ds1 = Dataset(([0, 1], [1, 2, 3], arr1), ['x', 'y'], 'z')
+        ds2 = Dataset(([0, 1, 2], [1, 2], arr2), ['x', 'y'], 'z')
+        hmap = HoloMap({1: ds1, 2: ds2})
+        with self.assertRaises(MergeError):
+            concat(hmap)
+
+    def test_dataset_array_init_hm(self):
+        "Tests support for arrays (homogeneous)"
+        raise SkipTest("Not supported")
+
+    # Disabled tests for NotImplemented methods
+    def test_dataset_add_dimensions_values_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_add_dimensions_values_hm_alias(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_reverse_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_vdim_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_reverse_vdim_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_vdim_hm_alias(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_1D_reduce_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_1D_reduce_hm_alias(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_2D_reduce_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_2D_reduce_hm_alias(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_2D_aggregate_partial_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_2D_aggregate_partial_hm_alias(self):
+        raise SkipTest("Not supported")
+
+    def test_aggregate_2d_with_spreadfn(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sample_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sample_hm_alias(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_groupby_drop_dims_with_vdim(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_groupby_drop_dims_dynamic_with_vdim(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_ndloc_slice_two_vdims(self):
+        raise SkipTest("Not supported")
+
+    def test_dim_to_coord(self):
+        dim = coord_to_dimension(self.cube.coords()[0])
+        self.assertEqual(dim.name, 'latitude')
+        self.assertEqual(dim.unit, 'degrees')
+
+    def test_initialize_cube(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube.dimensions(label=True),
+                         ['longitude', 'latitude', 'unknown'])
+
+    def test_initialize_cube_with_kdims(self):
+        cube = Dataset(self.cube, kdims=['longitude', 'latitude'])
+        self.assertEqual(cube.dimensions('key', True),
+                         ['longitude', 'latitude'])
+
+    def test_initialize_cube_with_vdims(self):
+        cube = Dataset(self.cube, vdims=['Quantity'])
+        self.assertEqual(cube.dimensions('value', True),
+                         ['Quantity'])
+
+    def test_dimension_values_kdim_expanded(self):
+        cube = Dataset(self.cube, kdims=['longitude', 'latitude'])
+        self.assertEqual(cube.dimension_values('longitude'),
+                         np.array([-1, -1, -1, 0,  0,  0,
+                                   1,  1,  1, 2,  2,  2], dtype=np.int32))
+
+    def test_dimension_values_kdim(self):
+        cube = Dataset(self.cube, kdims=['longitude', 'latitude'])
+        self.assertEqual(cube.dimension_values('longitude', expanded=False),
+                         np.array([-1,  0,  1, 2], dtype=np.int32))
+
+    def test_dimension_values_vdim(self):
+        cube = Dataset(self.cube, kdims=['longitude', 'latitude'])
+        self.assertEqual(cube.dimension_values('unknown', flat=False),
+                         np.array([[ 0,  4,  8],
+                                   [ 1,  5,  9],
+                                   [ 2,  6, 10],
+                                   [ 3,  7, 11]], dtype=np.int32).T)
+
+    def test_range_kdim(self):
+        cube = Dataset(self.cube, kdims=['longitude', 'latitude'])
+        self.assertEqual(cube.range('longitude'), (-1, 2))
+
+    def test_range_vdim(self):
+        cube = Dataset(self.cube, kdims=['longitude', 'latitude'])
+        self.assertEqual(cube.range('unknown'), (0, 11))
+
+    def test_select_index(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube.select(longitude=0).data.data,
+                         np.array([[1, 5, 9]], dtype=np.int32))
+
+    def test_select_slice(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube.select(longitude=(0, 1.01)).data.data,
+                         np.array([[1,  2], [5,  6], [9, 10]], dtype=np.int32))
+
+    def test_select_set(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube.select(longitude={0, 1}).data.data,
+                         np.array([[1,  2], [5,  6], [9, 10]], dtype=np.int32))
+
+    def test_select_multi_index(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube.select(longitude=0, latitude=0), 5)
+
+    def test_select_multi_slice1(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube.select(longitude=(0, 1.01),
+                                     latitude=(0, 1.01)).data.data,
+                         np.array([[5,  6], [9, 10]], dtype=np.int32))
+
+    def test_select_multi_slice2(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube.select(longitude={0, 2},
+                                     latitude={0, 2}).data.data,
+                         np.array([[5, 7]], dtype=np.int32))
+
+    def test_getitem_index(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube[0].data.data,
+                         np.array([[1, 5, 9]], dtype=np.int32))
+
+    def test_getitem_scalar(self):
+        cube = Dataset(self.cube)
+        self.assertEqual(cube[0, 0], 5)
+
+    def test_irregular_grid_data_values(self):
+        raise SkipTest('Irregular mesh data not supported by IrisInterface')
+
+    def test_irregular_grid_data_values_inverted_y(self):
+        raise SkipTest('Irregular mesh data not supported by IrisInterface')
+
+
+@attr(optional=1)
+class Image_IrisInterfaceTests(Image_ImageInterfaceTests):
+
+    datatype = 'cube'
+
+    def init_data(self):
+        xs = np.linspace(-9, 9, 10)
+        ys = np.linspace(0.5, 9.5, 10)
+        self.xs = xs
+        self.ys = ys
+        self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
+        self.image = Image((xs, ys, self.array))
+        self.image_inv = Image((xs[::-1], ys[::-1], self.array[::-1, ::-1]))
+
+    def test_init_data_datetime_xaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_init_data_datetime_yaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_init_bounds_datetime_xaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_init_bounds_datetime_yaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_init_densities_datetime_xaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_init_densities_datetime_yaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_range_datetime_xdim(self):
+        raise SkipTest("Not supported")
+
+    def test_range_datetime_ydim(self):
+        raise SkipTest("Not supported")
+
+    def test_dimension_values_datetime_xcoords(self):
+        raise SkipTest("Not supported")
+
+    def test_dimension_values_datetime_ycoords(self):
+        raise SkipTest("Not supported")
+
+    def test_slice_datetime_xaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_slice_datetime_yaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_reduce_to_scalar(self):
+        raise SkipTest("Not supported")
+
+    def test_reduce_x_dimension(self):
+        raise SkipTest("Not supported")
+
+    def test_reduce_y_dimension(self):
+        raise SkipTest("Not supported")
+
+    def test_aggregate_with_spreadfn(self):
+        raise SkipTest("Not supported")
+
+    def test_sample_datetime_xaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_sample_datetime_yaxis(self):
+        raise SkipTest("Not supported")

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ def package_assets(example_path):
 _required = [
     'bokeh >=0.12.15',   # not strictly required but shouldn't be problematic
     'cartopy >=0.14.2',  # prevents pip alone (requires external package manager)
-    'holoviews >=1.11.0a8',
+    'holoviews >=1.11.0a7',
     'numpy >=1.0',
     'param >=1.6.1'
 ]

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ def package_assets(example_path):
 _required = [
     'bokeh >=0.12.15',   # not strictly required but shouldn't be problematic
     'cartopy >=0.14.2',  # prevents pip alone (requires external package manager)
-    'holoviews >=1.11.0a4',
+    'holoviews >=1.11.0a8',
     'numpy >=1.0',
     'param >=1.6.1'
 ]


### PR DESCRIPTION
The iris interface used to live in HoloViews but since it is primarily used for geo applications and depends on cartopy it was decided the best place for it is in geoviews. This adds the interface and defers geopandas imports for the GeopandasInterface.