### PR TITLE
Completely rewrote geometry handling

### DIFF
--- a/examples/gallery/bokeh/filled_contours.ipynb
+++ b/examples/gallery/bokeh/filled_contours.ipynb
@@ -32,7 +32,7 @@
     "    \"\"\"Returns ``lons``, ``lats`` and ``data`` of some fake data.\"\"\"\n",
     "    nlats, nlons = shape\n",
     "    ys = np.linspace(-np.pi / 2, np.pi / 2, nlats)\n",
-    "    xs = np.linspace(-np.pi, np.pi, nlons)\n",
+    "    xs = np.linspace(0, 2*np.pi, nlons)\n",
     "    lons, lats = np.meshgrid(xs, ys)\n",
     "    wave = 0.75 * (np.sin(2 * lats) ** 8) * np.cos(4 * lons)\n",
     "    mean = 0.5 * np.cos(2 * lats) * ((np.sin(2 * lats)) ** 2 + 2)\n",
@@ -44,8 +44,7 @@
     "    return lons, lats, data\n",
     "\n",
     "lons, lats, data = sample_data()\n",
-    "contours = hv.operation.contours(gv.Image((lons, lats, data)),\n",
-    "                                 filled=True, levels=8).redim.range(z=(-1.1, 1.1))"
+    "contours = hv.operation.contours(gv.Image((lons, lats, data)), filled=True, levels=8).redim.range(z=(-1.1, 1.1))"
    ]
   },
   {
@@ -61,8 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Polygons [colorbar=True width=600 height=300 color_levels=12 infer_projection=True] (alpha=0.8 cmap='nipy_spectral') \n",
-    "gv.project(contours, projection=crs.Mollweide()) * gf.coastline"
+    "%%opts Polygons [colorbar=True width=600 height=300 color_levels=10 projection=crs.Mollweide()] (cmap='nipy_spectral') \n",
+    "contours * gf.coastline"
    ]
   }
  ],

--- a/examples/gallery/bokeh/katrina_track.ipynb
+++ b/examples/gallery/bokeh/katrina_track.ipynb
@@ -86,11 +86,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Shape [width=700 height=500 infer_projection=True] Polygons Path [show_legend=True apply_ranges=False]\n",
     "# Add proxy artists for legend\n",
-    "direct_hit = gv.Polygons([[(0,0)]], label='State directly intersects\\nwith track').opts(style=dict(color='red'))\n",
-    "within_2_deg = gv.Polygons([[(0,0)]], label='State is within \\n2 degrees of track').opts(style=dict(color='#FF7E00'))\n",
-    "gv.Overlay(shapes).relabel(title) * direct_hit * within_2_deg"
+    "direct_hit = gv.Polygons([[(0,0)]], label='State directly intersects with track').options(color='red', show_legend=True, apply_ranges=False)\n",
+    "within_2_deg = gv.Polygons([[(0,0)]], label='State is within 2 degrees of track').options(color='#FF7E00', show_legend=True, apply_ranges=False)\n",
+    "\n",
+    "(gv.Overlay(shapes) * direct_hit * within_2_deg).relabel(title).options(width=700, height=500, infer_projection=True)"
    ]
   }
  ],

--- a/examples/gallery/matplotlib/katrina_track.ipynb
+++ b/examples/gallery/matplotlib/katrina_track.ipynb
@@ -69,9 +69,9 @@
     "        facecolor = 'red'\n",
     "    elif state.intersects(track_buffer):\n",
     "        facecolor = '#FF7E00'\n",
-    "    shapes.append(gv.Shape(state).opts(style=dict(facecolor=facecolor)))\n",
-    "shapes.append(gv.Shape(track_buffer).opts(style=dict(alpha=0.5)))\n",
-    "shapes.append(gv.Shape(track).opts(style=dict(facecolor='none')))"
+    "    shapes.append(gv.Shape(state).options(facecolor=facecolor))\n",
+    "shapes.append(gv.Shape(track_buffer).options(alpha=0.5))\n",
+    "shapes.append(gv.Shape(track).options(facecolor='none'))"
    ]
   },
   {
@@ -87,11 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Polygons [show_legend=True apply_ranges=False]\n",
-    "# Add proxy artists for legend\n",
-    "direct_hit = gv.Polygons([[(0,0)]], label='State directly intersects\\nwith track').opts(style=dict(facecolor='red'))\n",
-    "within_2_deg = gv.Polygons([[(0,0)]], label='State is within \\n2 degrees of track').opts(style=dict(facecolor='#FF7E00'))\n",
-    "gv.Overlay(shapes).relabel(title) * direct_hit * within_2_deg"
+    "gv.Overlay(shapes).relabel(title)"
    ]
   }
  ],

--- a/examples/user_guide/Geometries.ipynb
+++ b/examples/user_guide/Geometries.ipynb
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also iterate over the geometries and wrap them all in an NdOverlay of ``gv.Shape`` Elements:"
+    "We can also supply a list of geometries directly to a Polygons or Path element:"
    ]
   },
   {
@@ -136,8 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts NdOverlay [aspect=2]\n",
-    "hv.NdOverlay({i: gv.Shape(s, crs=ccrs.PlateCarree()) for i, s in enumerate(land_geoms)})"
+    "gv.Polygons(land_geoms) + gv.Path(land_geoms)"
    ]
   },
   {
@@ -196,7 +195,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``from_records`` function optionally also supports merging the records and dataset directly. To merge them, supply the name of the shared attribute on which the merge is based via the ``on`` argument. If the name of attribute in the records and the dimension in the dataset match exactly, you can simply supply it as a string, otherwise supply a dictionary mapping between the attribute and column name. In this case we want to color the choropleth by the `'leaveVoteshare'`, which we define via the `value` argument. By default, the resulting `NdOverlay` of shapes will be indexed by an integer index. To draw the index from values in the dataset instead, you can request one or more indexes using the ``index`` argument. Finally we will declare the coordinate reference system in which this data is stored, which will in most cases be the simple Plate Carree projection.  We can then view the choropleth, with each shape colored by the specified value (the percentage who voted to leave the EU):"
+    "The ``from_records`` function optionally also supports merging the records and dataset directly. To merge them, supply the name of the shared attribute on which the merge is based via the ``on`` argument. If the name of attribute in the records and the dimension in the dataset match exactly, you can simply supply it as a string, otherwise supply a dictionary mapping between the attribute and column name. In this case we want to color the choropleth by the `'leaveVoteshare'`, which we define via the `value` argument.\n",
+    "\n",
+    "Additionally we can request one or more indexes using the ``index`` argument. Finally we will declare the coordinate reference system in which this data is stored, which will in most cases be the simple Plate Carree projection.  We can then view the choropleth, with each shape colored by the specified value (the percentage who voted to leave the EU):"
    ]
   },
   {
@@ -205,10 +206,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Shape (cmap='viridis')\n",
     "%output backend='bokeh'\n",
     "gv.Shape.from_records(shapes.records(), referendum, on='code', value='leaveVoteshare',\n",
-    "                     index=['name', 'regionName'], crs=ccrs.PlateCarree())"
+    "                     index=['name', 'regionName']).options(tools=['hover'], width=350, height=500)"
    ]
   },
   {
@@ -267,7 +267,7 @@
    "outputs": [],
    "source": [
     "%%opts Polygons [width=600 height=400 tools=['hover'] infer_projection=True] (cmap='tab20')\n",
-    "gv.Polygons(world, vdims=['continent',  'name', 'pop_est']).redim.range(Latitude=(-60, 90))"
+    "gv.Polygons(world, vdims=['continent',  'name', 'pop_est'])"
    ]
   },
   {

--- a/geoviews/data/__init__.py
+++ b/geoviews/data/__init__.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import param
 from holoviews.core.data import Dataset
 
+from . import geom_dict # noqa (API import)
+
 try:
     from . import geopandas # noqa (API import)
 except ImportError:

--- a/geoviews/data/__init__.py
+++ b/geoviews/data/__init__.py
@@ -3,22 +3,7 @@ from __future__ import absolute_import
 import param
 from holoviews.core.data import Dataset
 
-from . import geom_dict # noqa (API import)
-
-try:
-    from . import geopandas # noqa (API import)
-except ImportError:
-    pass
-except Exception as e:
-    param.main.warning('GeoPandas interface failed to import with '
-                       'following error: %s' % e)
-
-try:
-    from . import iris # noqa (API import)
-    Dataset.datatype.append('cube')
-except ImportError:
-    pass
-except Exception as e:
-    param.main.warning('Iris interface failed to import with '
-                       'following error: %s' % e)
+from .geom_dict import GeomDictInterface # noqa (API import)
+from .geopandas import GeoPandasInterface # noqa (API import)
+from .iris import CubeInterface # noqa (API import)
 

--- a/geoviews/data/__init__.py
+++ b/geoviews/data/__init__.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import
 
-import param
-from holoviews.core.data import Dataset
-
 from .geom_dict import GeomDictInterface # noqa (API import)
 from .geopandas import GeoPandasInterface # noqa (API import)
 from .iris import CubeInterface # noqa (API import)

--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -6,13 +6,11 @@ except ImportError:
     pass
 
 import numpy as np
-
-
 from holoviews.core.data import Interface, DictInterface, MultiInterface
 from holoviews.core.dimension import OrderedDict as cyODict, dimension_name
 from holoviews.core.util import isscalar
 
-from ..util import geom_types, geom_to_array
+from ..util import geom_types, geom_to_array, geom_length
 
 
 class GeomDictInterface(DictInterface):
@@ -96,7 +94,7 @@ class GeomDictInterface(DictInterface):
     def holes(cls, dataset):
         from shapely.geometry import Polygon, MultiPolygon
         geom = dataset.data['geometry']
-        if isinstance(geom, Polygon) and geom.interiors:
+        if isinstance(geom, Polygon):
             return [[[geom_to_array(h) for h in geom.interiors]]]
         elif isinstance(geom, MultiPolygon):
             return [[[geom_to_array(h) for h in g.interiors] for g in geom]]
@@ -125,7 +123,7 @@ class GeomDictInterface(DictInterface):
 
     @classmethod
     def length(cls, dataset):
-        return len(geom_to_array(dataset.data['geometry']))
+        return geom_length(dataset.data['geometry'])
 
     @classmethod
     def geom_dims(cls, dataset):
@@ -143,20 +141,25 @@ class GeomDictInterface(DictInterface):
         return DictInterface.values(dataset, dim, expanded, flat)
 
     @classmethod
+    def select(cls, dataset, selection_mask=None, **selection):
+        raise NotImplementedError('select operation not implemented on geometries')
+
+    @classmethod
     def iloc(cls, dataset, index):
-        raise NotImplementedError()
+        raise NotImplementedError('iloc operation not implemented for geometries.')
 
     @classmethod
     def sample(cls, dataset, samples=[]):
-        raise NotImplementedError()
+        raise NotImplementedError('sampling operation not implemented for geometries.')
 
     @classmethod
     def aggregate(cls, dataset, kdims, function, **kwargs):
-        raise NotImplementedError()
+        raise NotImplementedError('aggregate operation not implemented for geometries.')
 
     @classmethod
     def concat(cls, datasets, dimensions, vdims):
-        raise NotImplementedError()
+        raise NotImplementedError('concat operation not implemented for geometries.')
+
 
 MultiInterface.subtypes.insert(0, 'geom_dictionary')
 Interface.register(GeomDictInterface)

--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -1,9 +1,5 @@
 import sys
-from collections import OrderedDict, defaultdict
-try:
-    import itertools.izip as zip
-except ImportError:
-    pass
+from collections import OrderedDict
 
 import numpy as np
 from holoviews.core.data import Interface, DictInterface, MultiInterface

--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -1,0 +1,145 @@
+import sys
+from collections import OrderedDict, defaultdict
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
+
+import numpy as np
+
+
+from holoviews.core.data import Interface, DictInterface, MultiInterface
+from holoviews.core.dimension import OrderedDict as cyODict, dimension_name
+from holoviews.core.util import isscalar
+
+from ..util import geom_types, geom_to_array
+
+
+class GeomDictInterface(DictInterface):
+
+    datatype = 'geom_dictionary'
+
+    @classmethod
+    def applies(cls, obj):
+        if 'shapely' not in sys.modules:
+            return False
+        return ((isinstance(obj, cls.types) and 'geometry' in obj
+                 and isinstance(obj['geometry'], geom_types)) or
+                isinstance(obj, geom_types))
+
+    @classmethod
+    def init(cls, eltype, data, kdims, vdims):
+        odict_types = (OrderedDict, cyODict)
+        if kdims is None:
+            kdims = eltype.kdims
+        if vdims is None:
+            vdims = eltype.vdims
+
+        dimensions = [dimension_name(d) for d in kdims + vdims]
+        if isinstance(data, geom_types):
+            data = {'geometry': data}
+
+        if not cls.applies(data):
+            raise ValueError("GeomDictInterface only handles dictionary types "
+                             "containing a 'geometry' key and shapely geometry "
+                             "value.")
+
+        unpacked = []
+        for d, vals in data.items():
+            if isinstance(d, tuple):
+                vals = np.asarray(vals)
+                if vals.shape == (0,):
+                    for sd in d:
+                        unpacked.append((sd, np.array([], dtype=vals.dtype)))
+                elif not vals.ndim == 2 and vals.shape[1] == len(d):
+                    raise ValueError("Values for %s dimensions did not have "
+                                     "the expected shape.")
+                else:
+                    for i, sd in enumerate(d):
+                        unpacked.append((sd, vals[:, i]))
+            elif d not in dimensions:
+                unpacked.append((d, vals))
+            else:
+                if not isscalar(vals):
+                    vals = np.asarray(vals)
+                    if not vals.ndim == 1 and d in dimensions:
+                        raise ValueError('DictInterface expects data for each column to be flat.')
+                unpacked.append((d, vals))
+
+        if not cls.expanded([vs for d, vs in unpacked if d in dimensions and not isscalar(vs)]):
+            raise ValueError('DictInterface expects data to be of uniform shape.')
+        if isinstance(data, odict_types):
+            data.update(unpacked)
+        else:
+            data = OrderedDict(unpacked)
+
+        return data, {'kdims':kdims, 'vdims':vdims}, {}
+
+    @classmethod
+    def validate(cls, dataset):
+        assert len([d for d in dataset.kdims + dataset.vdims
+                    if d.name not in dataset.data]) == 2
+
+    @classmethod
+    def dimension_type(cls, dataset, dim):
+        name = dataset.get_dimension(dim, strict=True).name
+        if name in cls.geom_dims(dataset):
+            return float
+        values = dataset.data[name]
+        return type(values) if isscalar(values) else values.dtype.type
+
+    @classmethod
+    def redim(cls, dataset, dimensions):
+        pass
+
+    @classmethod
+    def length(cls, dataset):
+        return len(geom_to_array(dataset.data['geometry']))
+
+    @classmethod
+    def geom_dims(cls, dataset):
+        return [d for d in dataset.kdims + dataset.vdims
+                if d.name not in dataset.data]
+    
+    @classmethod
+    def xdim(cls, dataset):
+        return [d for d in dataset.kdims + dataset.vdims
+                if d.name not in dataset.data][0]
+
+    @classmethod
+    def ydim(cls, dataset):
+        return [d for d in dataset.kdims + dataset.vdims
+                if d.name not in dataset.data][1]
+
+    @classmethod
+    def values(cls, dataset, dim, expanded=True, flat=True):
+        d = dataset.get_dimension(dim)
+        array = geom_to_array(dataset.data['geometry'])
+        if d is cls.xdim(dataset):
+            return array[:, 0]
+        elif d is cls.ydim(dataset):
+            return array[:, 1]
+        return DictInterface.values(dataset, dim, expanded, flat)
+
+    @classmethod
+    def validate(cls, dataset, vdims=True):
+        pass
+
+    @classmethod
+    def iloc(cls, dataset, index):
+        raise NotImplementedError()
+
+    @classmethod
+    def sample(cls, dataset, samples=[]):
+        raise NotImplementedError()
+
+    @classmethod
+    def aggregate(cls, dataset, kdims, function, **kwargs):
+        raise NotImplementedError()
+
+    @classmethod
+    def concat(cls, datasets, dimensions, vdims):
+        raise NotImplementedError()
+
+MultiInterface.subtypes.append('geom_dictionary')
+Interface.register(GeomDictInterface)

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -8,7 +8,6 @@ import pandas as pd
 from holoviews.core.data import Dataset, Interface, MultiInterface, PandasInterface
 from holoviews.core.data.interface  import DataError
 from holoviews.core.dimension import dimension_name
-from holoviews.core.util import max_range
 from holoviews.element import Path
 
 from ..util import geom_to_array, geom_types, geom_length
@@ -82,7 +81,7 @@ class GeoPandasInterface(MultiInterface):
                             'coordinates but %d dimensions were found '
                             'which did not refer to any columns.'
                             % (type(dataset).__name__, len(geom_dims)), cls)
-        not_found = [d.name for d in dataset.dimensions()
+        not_found = [d.name for d in dataset.dimensions(dim_types)
                      if d not in geom_dims and d.name not in dataset.data]
         if not_found:
             raise DataError("Supplied data does not contain specified "
@@ -216,8 +215,6 @@ class GeoPandasInterface(MultiInterface):
 
     @classmethod
     def split(cls, dataset, start, end, datatype, **kwargs):
-        from shapely.geometry import Polygon, MultiPolygon
-
         objs = []
         xdim, ydim = dataset.kdims[:2]
         if not len(dataset.data):
@@ -232,7 +229,6 @@ class GeoPandasInterface(MultiInterface):
                 objs.append(row['geometry'])
                 continue
             geom = row.geometry
-            geoms = geom if isinstance(geom, MultiPolygon) else [geom]
             arr = geom_to_array(geom)
             d = {xdim.name: arr[:, 0], ydim.name: arr[:, 1]}
             d.update({vd.name: row[vd.name] for vd in dataset.vdims})

--- a/geoviews/data/iris.py
+++ b/geoviews/data/iris.py
@@ -6,6 +6,7 @@ from itertools import product
 
 import numpy as np
 
+from holoviews.core.data import Dataset
 from holoviews.core.data.interface import Interface, DataError
 from holoviews.core.data.grid import GridInterface
 from holoviews.core.dimension import Dimension, asdim
@@ -364,7 +365,6 @@ class CubeInterface(GridInterface):
         Apply a selection to the data.
         """
         import iris
-        
         constraint = cls.select_to_constraint(dataset, selection)
         pre_dim_coords = [c.name() for c in dataset.data.dim_coords]
         indexed = cls.indexed(dataset, selection)
@@ -380,3 +380,4 @@ class CubeInterface(GridInterface):
 
 
 Interface.register(CubeInterface)
+Dataset.datatype.append('cube')

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -31,8 +31,8 @@ try:
 except:
     WebMapTileService = None
 
-from ..util import (path_to_geom, polygon_to_geom, geom_to_array,
-                    load_tiff, from_xarray, poly_types)
+from ..util import (path_to_geom, polygon_to_geom, load_tiff,
+                    from_xarray, poly_types)
 
 geographic_types = (GoogleTiles, cFeature, BaseGeometry)
 
@@ -633,7 +633,6 @@ class Shape(Dataset):
             vdims = []
 
         data = []
-        notfound = False
         for i, rec in enumerate(records):
             geom = {}
             if dataset:
@@ -649,7 +648,6 @@ class Shape(Dataset):
                 geom.update(values)
 
             if index:
-                key = []
                 for kdim in kdims:
                     if kdim in ddims and len(row):
                         k = row[kdim.name][0]

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -234,29 +234,6 @@ class VectorField(_Element, HvVectorField):
                                 Dimension('Magnitude')], bounds=(1, None))
 
 
-
-class LineContours(_Element, HvImage):
-    """
-    Contours represents a 2D array of some quantity with
-    some associated coordinates, which may be discretized
-    into one or more line contours.
-    """
-
-    vdims = param.List(default=[Dimension('z')], bounds=(1, 1))
-
-    group = param.String(default='LineContours')
-
-
-class FilledContours(LineContours):
-    """
-    Contours represents a 2D array of some quantity with
-    some associated coordinates, which may be discretized
-    into one or more filled contours.
-    """
-
-    group = param.String(default='FilledContours')
-
-
 class Image(_Element, HvImage):
     """
     Image represents a 2D array of some quantity with
@@ -318,6 +295,26 @@ class QuadMesh(_Element, HvQuadMesh):
         nodes = TriMesh.node_type(trimesh.nodes.data, **node_params)
         return TriMesh((trimesh.data, nodes), crs=self.crs,
                        **util.get_param_values(trimesh))
+
+
+class LineContours(QuadMesh):
+    """
+    LineContours represents a 2D array of some quantity with
+    some associated coordinates, which may be discretized
+    into one or more line contours.
+    """
+
+    group = param.String(default='LineContours')
+
+
+class FilledContours(QuadMesh):
+    """
+    Contours represents a 2D array of some quantity with
+    some associated coordinates, which may be discretized
+    into one or more filled contours.
+    """
+
+    group = param.String(default='FilledContours')
 
 
 class RGB(_Element, HvRGB):

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -58,6 +58,8 @@ class project_path(_project_operation):
 
         import shapely
         boundary = crs.project_geometry(Polygon(proj.boundary), proj)
+        if not boundary:
+            boundary = Polygon(crs.boundary)
         bounds = [round(b, 10) for b in boundary.bounds]
         xoffset = round((boundary.bounds[2]-boundary.bounds[0])/2.)
         if isinstance(element, Polygons):

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -66,9 +66,9 @@ class project_path(_project_operation):
         bounds = [round(b, 10) for b in boundary.bounds]
         xoffset = round((boundary.bounds[2]-boundary.bounds[0])/2.)
         if isinstance(element, Polygons):
-            geoms = polygons_to_geom_dicts(element)
+            geoms = polygons_to_geom_dicts(element, skip_invalid=False)
         else:
-            geoms = path_to_geom_dicts(element)
+            geoms = path_to_geom_dicts(element, skip_invalid=False)
 
         data_bounds = max_extents([g['geometry'].bounds for g in geoms])
         total_bounds = tuple(round(b, 10) for b in data_bounds)

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -1,4 +1,3 @@
-import warnings
 import logging
 
 import param
@@ -10,7 +9,7 @@ from cartopy.img_transform import warp_array, _determine_bounds
 from holoviews.core.data import MultiInterface
 from holoviews.core.util import cartesian_product, get_param_values, max_extents, pd
 from holoviews.operation import Operation
-from shapely.geometry import Polygon, LineString, MultiPolygon, MultiLineString
+from shapely.geometry import Polygon, MultiPolygon
 from shapely.geometry.collection import GeometryCollection
 
 from ..data import GeoPandasInterface

--- a/geoviews/plotting/__init__.py
+++ b/geoviews/plotting/__init__.py
@@ -1,6 +1,21 @@
+from holoviews.core.options import Compositor
+from holoviews.operation.element import contours
+
+from ..element import LineContours, FilledContours, Contours, Polygons
 from . import mpl # noqa
 
 try:
     from . import bokeh # noqa
 except ImportError:
     pass
+
+Compositor.register(Compositor("LineContours", contours, None,
+                               'data', transfer_options=True,
+                               transfer_parameters=True,
+                               output_type=Contours,
+                               backends=['bokeh', 'matplotlib']))
+Compositor.register(Compositor("FilledContours", contours.instance(filled=True),
+                               None, 'data', transfer_options=True,
+                               transfer_parameters=True,
+                               output_type=Polygons,
+                               backends=['bokeh', 'matplotlib']))

--- a/geoviews/plotting/__init__.py
+++ b/geoviews/plotting/__init__.py
@@ -1,7 +1,7 @@
 from holoviews.core.options import Compositor
 from holoviews.operation.element import contours
 
-from ..element import LineContours, FilledContours, Contours, Polygons
+from ..element import Contours, Polygons
 from . import mpl # noqa
 
 try:

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -20,7 +20,7 @@ from holoviews.plotting.bokeh.util import mpl_to_bokeh
 from ...element import (WMTS, Points, Polygons, Path, Contours, Shape,
                         Image, Feature, Text, RGB, Nodes, EdgePaths,
                         Graph, TriMesh, QuadMesh, VectorField, Labels,
-                        HexTiles)
+                        HexTiles, LineContours, FilledContours)
 from ...operation import (project_image, project_shape, project_points,
                           project_path, project_graph, project_quadmesh)
 from ...tile_sources import _ATTRIBUTIONS
@@ -134,6 +134,24 @@ class GeoContourPlot(GeoPlot, ContourPlot):
     _project_operation = project_path
 
 
+class LineContourPlot(GeoContourPlot):
+    """
+    Draws a contour plot.
+    """
+
+    levels = param.ClassSelector(default=10, class_=(list, int), doc="""
+        A list of scalar values used to specify the contour levels.""")
+
+
+class FilledContourPlot(GeoPolygonPlot):
+    """
+    Draws a filled contour plot.
+    """
+
+    levels = param.ClassSelector(default=10, class_=(list, int), doc="""
+        A list of scalar values used to specify the contour levels.""")
+    
+
 class GeoPathPlot(GeoPlot, PathPlot):
 
     _project_operation = project_path
@@ -245,6 +263,8 @@ Store.register({WMTS: TilePlot,
                 Shape: GeoShapePlot,
                 Image: GeoRasterPlot,
                 RGB: GeoRGBPlot,
+                LineContours: LineContourPlot,
+                FilledContours: FilledContourPlot,
                 Feature: FeaturePlot,
                 HexTiles: HexTilesPlot,
                 Text: GeoTextPlot,

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -24,12 +24,10 @@ from ...element import (WMTS, Points, Polygons, Path, Contours, Shape,
 from ...operation import (project_image, project_shape, project_points,
                           project_path, project_graph, project_quadmesh)
 from ...tile_sources import _ATTRIBUTIONS
-from ...util import geom_to_array
+from ...util import geom_to_array, poly_types, line_types
 from .plot import GeoPlot, GeoOverlayPlot
 from . import callbacks # noqa
 
-line_types = (shapely.geometry.MultiLineString, shapely.geometry.LineString)
-poly_types = (shapely.geometry.MultiPolygon, shapely.geometry.Polygon)
 
 class TilePlot(GeoPlot):
 
@@ -154,50 +152,17 @@ class GeoTriMeshPlot(GeoPlot, TriMeshPlot):
 class GeoShapePlot(GeoPolygonPlot):
 
     def get_data(self, element, ranges, style):
-        if self.static_source:
-            data = {}
+        if not isinstance(element.data['geometry'], poly_types):
+            style['fill_alpha'] = 0
+        if isinstance(element.data['geometry'], line_types):
+            el_type = Contours
+            style['plot_method'] = 'multi_line'
+            style.pop('fill_color', None)
+            style.pop('fill_alpha', None)
         else:
-            if self.geographic and element.crs != self.projection:
-                element = project_shape(element, projection=self.projection)
-            xs, ys = geom_to_array(element.geom()).T
-            if self.invert_axes: xs, ys = ys, xs
-            data = dict(xs=[xs], ys=[ys])
-
-        mapping = dict(self._mapping)
-        dim = element.vdims[0].name if element.vdims else None
-        if element.level is not None:
-            cmap = style.get('palette', style.get('cmap', None))
-            if cmap and dim:
-                cdim = element.vdims[0]
-                dim_name = util.dimension_sanitizer(cdim.name)
-                cmapper = self._get_colormapper(cdim, element, ranges, style)
-                data[dim_name] = [element.level]
-                mapping['fill_color'] = {'field': dim_name,
-                                         'transform': cmapper}
-
-        if 'hover' in self.tools+self.default_tools:
-            if dim:
-                dim_name = util.dimension_sanitizer(dim)
-                data[dim_name] = [element.level]
-            for k, v in self.overlay_dims.items():
-                dim = util.dimension_sanitizer(k.name)
-                data[dim] = [v for _ in range(len(xs))]
-        return data, mapping, style
-
-    def _init_glyph(self, plot, mapping, properties):
-        """
-        Returns a Bokeh glyph object.
-        """
-        properties = mpl_to_bokeh(properties)
-        if isinstance(self.current_frame.data, line_types):
-            properties = {k: v for k, v in properties.items()
-                          if 'fill_' not in k}
-            plot_method = plot.multi_line
-        else:
-            plot_method = plot.patches
-        renderer = plot_method(**dict(properties, **mapping))
-        return renderer, renderer.glyph
-
+            el_type = Polygons
+        polys = el_type([element.data], crs=element.crs, **util.get_param_values(element))
+        return super(GeoShapePlot, self).get_data(polys, ranges, style)
 
 
 class FeaturePlot(GeoPolygonPlot):
@@ -210,34 +175,27 @@ class FeaturePlot(GeoPolygonPlot):
         proj = self.projection
         if self.global_extent and range_type in ('combined', 'data'):
             (x0, x1), (y0, y1) = proj.x_limits, proj.y_limits
-            return (x0, y0, x1, y1)
+            return tuple(round(c, 12) for c in (x0, y0, x1, y1))
         elif self.overlaid:
             return (np.NaN,)*4
         return super(FeaturePlot, self).get_extents(element, ranges, range_type)
 
-
     def get_data(self, element, ranges, style):
         mapping = dict(self._mapping)
         if self.static_source: return {}, mapping, style
-
         feature = copy.copy(element.data)
         feature.scale = self.scale
         geoms = list(feature.geometries())
         if isinstance(geoms[0], line_types):
-            self._plot_methods = dict(single='multi_line')
+            el_type = Contours
+            style['plot_method'] = 'multi_line'
+            style.pop('fill_color', None)
+            style.pop('fill_alpha', None)
         else:
-            self._plot_methods = dict(single='patches', batched='patches')
-        geoms = [self.projection.project_geometry(geom, element.crs)
-                 for geom in geoms]
-
-        arrays = []
-        for geom in geoms:
-            if geom == []:
-                continue
-            arrays.append(geom_to_array(geom).T)
-        xs, ys = zip(*arrays) if arrays else ([], [])
-        data = dict(xs=list(xs), ys=list(ys))
-        return data, mapping, style
+            el_type = Polygons
+        polys = el_type(geoms, crs=element.crs, **util.get_param_values(element))
+        return super(FeaturePlot, self).get_data(polys, ranges, style)
+        
 
 
 class GeoTextPlot(GeoPlot, TextPlot):

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -2,7 +2,6 @@ import copy
 
 import param
 import numpy as np
-import shapely.geometry
 from cartopy.crs import GOOGLE_MERCATOR
 from bokeh.models import WMTSTileSource, BBoxTileSource, QUADKEYTileSource
 
@@ -15,16 +14,15 @@ from holoviews.plotting.bokeh.graphs import TriMeshPlot, GraphPlot
 from holoviews.plotting.bokeh.hex_tiles import hex_binning, HexTilesPlot
 from holoviews.plotting.bokeh.path import PolygonPlot, PathPlot, ContourPlot
 from holoviews.plotting.bokeh.raster import RasterPlot, RGBPlot, QuadMeshPlot
-from holoviews.plotting.bokeh.util import mpl_to_bokeh
 
 from ...element import (WMTS, Points, Polygons, Path, Contours, Shape,
                         Image, Feature, Text, RGB, Nodes, EdgePaths,
                         Graph, TriMesh, QuadMesh, VectorField, Labels,
                         HexTiles, LineContours, FilledContours)
-from ...operation import (project_image, project_shape, project_points,
-                          project_path, project_graph, project_quadmesh)
+from ...operation import (project_image, project_points, project_path,
+                          project_graph, project_quadmesh)
 from ...tile_sources import _ATTRIBUTIONS
-from ...util import geom_to_array, poly_types, line_types
+from ...util import poly_types, line_types
 from .plot import GeoPlot, GeoOverlayPlot
 from . import callbacks # noqa
 

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -82,7 +82,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         fig = super(GeoPlot, self).initialize_plot(ranges, plot, plots, **opts)
         if self.geographic and self.show_bounds and not self.overlaid:
             from . import GeoShapePlot
-            shape = Shape(self.projection.boundary, crs=self.projection)
+            shape = Shape(self.projection.boundary, crs=self.projection).options(fill_alpha=0)
             shapeplot = GeoShapePlot(shape, projection=self.projection,
                                      overlaid=True, renderer=self.renderer)
             shapeplot.initialize_plot(plot=fig)

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -346,7 +346,7 @@ class GeoShapePlot(GeometryPlot, PolygonPlot):
                 self._norm_kwargs(element, ranges, style, vdim)
                 style['clim'] = style.pop('vmin'), style.pop('vmax')
                 style['array'] = np.array([value])
-            return ([element.data], element.crs), style, {}
+            return ([element.data['geometry']], element.crs), style, {}
         else:
             SkipRendering('Shape can only be plotted on geographic plot, '
                           'supply a coordinate reference system.')

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -14,14 +14,12 @@ from holoviews.core import Store, HoloMap, Layout, Overlay, Element, NdLayout
 from holoviews.core import util
 from holoviews.core.data import GridInterface
 from holoviews.core.options import SkipRendering, Options
-from holoviews.plotting.mpl import (ElementPlot, ColorbarPlot, PointPlot,
-                                    AnnotationPlot, TextPlot,
-                                    LayoutPlot as HvLayoutPlot,
-                                    OverlayPlot as HvOverlayPlot,
-                                    PathPlot, PolygonPlot, RasterPlot,
-                                    ContourPlot, GraphPlot, TriMeshPlot,
-                                    QuadMeshPlot, VectorFieldPlot,
-                                    HexTilesPlot, LabelsPlot)
+from holoviews.plotting.mpl import (
+    ElementPlot, PointPlot, AnnotationPlot, TextPlot, LabelsPlot,
+    LayoutPlot as HvLayoutPlot, OverlayPlot as HvOverlayPlot,
+    PathPlot, PolygonPlot, RasterPlot, ContourPlot, GraphPlot,
+    TriMeshPlot, QuadMeshPlot, VectorFieldPlot, HexTilesPlot
+)
 from holoviews.plotting.mpl.util import get_raster_array
 
 

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -130,54 +130,6 @@ class GeoPlot(ProjectionPlot, ElementPlot):
             pass
 
 
-class LineContourPlot(GeoPlot, ColorbarPlot):
-    """
-    Draws a contour plot.
-    """
-
-    colorbar = param.Boolean(default=True)
-
-    levels = param.ClassSelector(default=5, class_=(int, list), doc="""
-        The levels of the contour as a number or list.""")
-
-    style_opts = ['antialiased', 'alpha', 'cmap', 'linewidths', 'colors']
-
-    _plot_methods = dict(single='contour')
-
-    def get_data(self, element, ranges, style):
-        args = geo_mesh(element)
-        style.pop('label', None)
-        if isinstance(self.levels, int):
-            args += (self.levels,)
-        else:
-            style['levels'] = self.levels
-        style['transform'] = element.crs
-        return args, style, {}
-
-
-    def teardown_handles(self):
-        """
-        Iterate over the artists in the collection and remove
-        them individually.
-        """
-        if 'artist' in self.handles:
-            for coll in self.handles['artist'].collections:
-                try:
-                    coll.remove()
-                except ValueError:
-                    pass
-
-
-class FilledContourPlot(LineContourPlot):
-    """
-    Draws a filled contour plot.
-    """
-
-    style_opts = ['antialiased', 'alpha', 'cmap', 'linewidths']
-
-    _plot_methods = dict(single='contourf')
-
-
 
 class GeoImagePlot(GeoPlot, RasterPlot):
     """
@@ -329,6 +281,24 @@ class GeoPolygonPlot(GeoPlot, PolygonPlot):
     apply_ranges = param.Boolean(default=True)
 
     _project_operation = project_path
+
+
+class LineContourPlot(GeoContourPlot):
+    """
+    Draws a contour plot.
+    """
+
+    levels = param.ClassSelector(default=10, class_=(list, int), doc="""
+        A list of scalar values used to specify the contour levels.""")
+
+
+class FilledContourPlot(GeoPolygonPlot):
+    """
+    Draws a filled contour plot.
+    """
+
+    levels = param.ClassSelector(default=10, class_=(list, int), doc="""
+        A list of scalar values used to specify the contour levels.""")
 
 
 class GeoShapePlot(GeometryPlot, PolygonPlot):

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -267,10 +267,11 @@ def path_to_geom_dicts(path, skip_invalid=True):
             if len(arr) == 1:
                 if skip_invalid:
                     continue
-                poly = Point(arr[0])
+                g = Point(arr[0])
                 invalid = True
             else:
-                subpaths.append(LineString(arr))
+                g = LineString(arr)
+            subpaths.append(g)
 
         if invalid:
             geoms += [dict(path, geometry=sp) for sp in subpaths]

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -156,8 +156,8 @@ def polygons_to_geom_dicts(polygons, skip_invalid=True):
 
     polys = []
     xdim, ydim = polygons.kdims
-    has_holes = polygons.interface.has_holes(polygons)
-    holes = polygons.interface.holes(polygons) if has_holes else None
+    has_holes = polygons.has_holes
+    holes = polygons.holes() if has_holes else None
     for i, polygon in enumerate(polygons.split(datatype='columns')):
         array = np.column_stack([polygon.pop(xdim.name), polygon.pop(ydim.name)])
         splits = np.where(np.isnan(array[:, :2].astype('float')).sum(axis=1))[0]
@@ -192,6 +192,8 @@ def polygons_to_geom_dicts(polygons, skip_invalid=True):
             geom = subpolys[0]
         elif subpolys:
             geom = MultiPolygon(subpolys)
+        else:
+            continue
         polygon['geometry'] = geom
         polys.append(polygon)
     return polys

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -142,7 +142,6 @@ def path_to_geom(path, multi=True, skip_invalid=True):
 def polygon_to_geom(poly, multi=True, skip_invalid=True):
     lines = []
     datatype = 'geom' if poly.interface.datatype == 'geodataframe' else 'array'
-    has_holes = poly.interface.has_holes(poly)
     for path in poly.split(datatype=datatype):
         if datatype == 'array':
             splits = np.where(np.isnan(path[:, :2].astype('float')).sum(axis=1))[0]

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -294,12 +294,12 @@ def geom_length(geom):
         return 1
     if hasattr(geom, 'exterior'):
         geom = geom.exterior
-    if hasattr(geom, 'array_interface_base'):
+    if not geom.geom_type.startswith('Multi') and hasattr(geom, 'array_interface_base'):
         return len(geom.array_interface_base['data'])//2
     else:
         length = 0
         for g in geom:
-            length += geom_length(geom)
+            length += geom_length(g)
         return length
 
 

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -165,7 +165,9 @@ def polygons_to_geom_dicts(polygons, skip_invalid=True):
 
         invalid = False
         subpolys = []
-        subholes = [LinearRing(h) for h in holes[i]] if holes else []
+        subholes = None
+        if has_holes:
+            subholes = [[LinearRing(h) for h in hs] for hs in holes[i]]
         for j, arr in enumerate(arrays):
             if j != (len(arrays)-1):
                 arr = arr[:-1] # Drop nan
@@ -176,10 +178,10 @@ def polygons_to_geom_dicts(polygons, skip_invalid=True):
                 poly = LineString(arr)
                 invalid = True
             elif not len(splits):
-                poly = Polygon(arr, subholes)
+                poly = Polygon(arr, (subholes[j] if has_holes else []))
             else:
                 poly = Polygon(arr)
-                hs = [h for h in subholes if poly.intersects(h)]
+                hs = [h for h in subholes[j]] if has_holes else []
                 poly = Polygon(poly.exterior, holes=hs)
             subpolys.append(poly)
 


### PR DESCRIPTION
This PR completely overhauls handling of paths, polygons and geometries in GeoViews. First of all it introduces a ``GeomDictionaryInterface`` which can process shapely geometries in the form:

```python
{'geometry': <shapely.Geometry>, 'value': 1, 'index': 1, ...}
```

This means that the ``MultiInterface`` interface can process lists of these objects, providing a native representation of geometries and value dimensions without relying on geopandas. Conversion from geopandas to this new format is as simple as:

```python
[row.to_dict() for _, row in gdf.iterrows()]
```

Secondly it provides utilities to convert all supported types of path/polygon data to this format, which hugely simplifies the projection operations since everything can now uniformly operate on shapely geometries.

Lastly this PR adds support for handling polygon holes, which has been a longstanding limitation.

- Depends on https://github.com/ioam/holoviews/pull/3092
- Closes https://github.com/pyviz/geoviews/issues/148
- Closes https://github.com/pyviz/geoviews/issues/214
- Closes https://github.com/pyviz/geoviews/issues/234
- [x] Add GeomDictInterface
- [x] Rewrite project operation to work on consistent data format
- [x] Rewrite Shape element to work with new data format
- [x] Rewrite bokeh plotting classes
- [x] Rewrite matplotlib plotting classes
- [x] Write tests
- [x] Update docs