### PR TITLE
Add projected grid lines to gv feature

### DIFF
--- a/geoviews/feature.py
+++ b/geoviews/feature.py
@@ -8,3 +8,6 @@ land      = Feature(cf.LAND, group='Land')
 lakes     = Feature(cf.LAKES, group='Lakes')
 ocean     = Feature(cf.OCEAN, group='Ocean')
 rivers    = Feature(cf.RIVERS, group='Rivers')
+grid      = Feature(cf.NaturalEarthFeature(category='physical',
+                                           name='graticules_30',
+                                           scale='110m'), group='Grid')

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -308,4 +308,5 @@ options.Feature.Land   = Options('style', fill_color='#efefdb', line_color='#efe
 options.Feature.Ocean  = Options('style', fill_color='#97b6e1', line_color='#97b6e1')
 options.Feature.Lakes  = Options('style', fill_color='#97b6e1', line_color='#97b6e1')
 options.Feature.Rivers = Options('style', line_color='#97b6e1')
+options.Feature.Grid = Options('style', line_width=0.5, alpha=0.5, line_color='gray')
 options.Shape = Options('style', line_color='black', fill_color='#30A2DA')

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -65,6 +65,12 @@ class GeoPlot(ProjectionPlot, ElementPlot):
             show_bounds = self._traverse_options(element, 'plot', ['show_bounds'],
                                                  defaults=False)
             self.show_bounds = not any(not sb for sb in show_bounds['show_bounds'])
+            if self.show_grid:
+                param.main.warning(
+                    'Grid lines do not reflect {0}; to do so '
+                    'multiply the current element by gv.feature.grid() '
+                    'and disable the show_grid option.'.format(self.projection)
+                )
 
     def _axis_properties(self, axis, key, plot, dimension=None,
                          ax_mapping={'x': 0, 'y': 1}):


### PR DESCRIPTION
I was thinking of adding it to bokeh/plot.py/GeoPlot, but I didn't know how to do it without making the resulting element a GeoOverlayPlot automatically so I thought maybe just make it more accessible as a feature

![image](https://user-images.githubusercontent.com/15331990/47278639-64974c00-d57f-11e8-9ffe-cf10db6418ca.png)
