### PR TITLE
Fixed scaling of features in cartopy 0.17

### DIFF
--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -199,8 +199,11 @@ class FeaturePlot(GeoPolygonPlot):
     def get_data(self, element, ranges, style):
         mapping = dict(self._mapping)
         if self.static_source: return {}, mapping, style
-        feature = copy.copy(element.data)
-        feature.scale = self.scale
+        if hasattr(element.data, 'with_scale'):
+            feature = element.data.with_scale(self.scale)
+        else:
+            feature = copy.copy(element.data)
+            feature.scale = self.scale
         geoms = list(feature.geometries())
         if isinstance(geoms[0], line_types):
             el_type = Contours

--- a/geoviews/plotting/bokeh/callbacks.py
+++ b/geoviews/plotting/bokeh/callbacks.py
@@ -11,7 +11,7 @@ from holoviews.plotting.bokeh.callbacks import (
 from holoviews.streams import (
     Stream, PointerXY, RangeXY, RangeX, RangeY, PointerX, PointerY,
     BoundsX, BoundsY, Tap, SingleTap, DoubleTap, MouseEnter, MouseLeave,
-    Bounds, BoundsXY, PolyDraw, PolyEdit, PointDraw, BoxEdit
+    BoundsXY, PolyDraw, PolyEdit, PointDraw, BoxEdit
 )
 
 from ...element.geo import _Element, Shape
@@ -297,7 +297,6 @@ except:
 callbacks[RangeXY]     = GeoRangeXYCallback
 callbacks[RangeX]      = GeoRangeXCallback
 callbacks[RangeY]      = GeoRangeYCallback
-callbacks[Bounds]      = GeoBoundsXYCallback
 callbacks[BoundsXY]    = GeoBoundsXYCallback
 callbacks[BoundsX]     = GeoBoundsXCallback
 callbacks[BoundsY]     = GeoBoundsYCallback

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -352,8 +352,11 @@ class FeaturePlot(GeoPlot):
                   'visible']
 
     def get_data(self, element, ranges, style):
-        feature = copy.copy(element.data)
-        feature.scale = self.scale
+        if hasattr(element.data, 'with_scale'):
+            feature = element.data.with_scale(self.scale)
+        else:
+            feature = copy.copy(element.data)
+            feature.scale = self.scale
         return (feature,), style, {}
 
     def init_artists(self, ax, plot_args, plot_kwargs):


### PR DESCRIPTION
Cartopy 0.17 no longer allows setting the scale on a feature but does add a new with_scale method.