### PR TITLE
Improved handling of non-default central longitudes

### DIFF
--- a/examples/gallery/bokeh/filled_contours.ipynb
+++ b/examples/gallery/bokeh/filled_contours.ipynb
@@ -46,7 +46,9 @@
     "    return lons, lats, data\n",
     "\n",
     "lons, lats, data = sample_data()\n",
-    "contours = hv.operation.contours(gv.Image((lons, lats, data)), filled=True, levels=8).redim.range(z=(-1.1, 1.1))"
+    "\n",
+    "# Make sure we declare the central longitude\n",
+    "contours = gv.FilledContours((lons, lats, data), crs=crs.PlateCarree(central_longitude=180))"
    ]
   },
   {
@@ -63,7 +65,7 @@
    "outputs": [],
    "source": [
     "(contours * gf.coastline).opts(\n",
-    "    opts.Polygons(colorbar=True, width=600, height=300, color_levels=10, projection=crs.Mollweide(), cmap='nipy_spectral'))"
+    "    opts.FilledContours(levels=8, color_levels=10, cmap='nipy_spectral', colorbar=True, width=600, height=300, projection=crs.Mollweide()))"
    ]
   }
  ],

--- a/examples/gallery/matplotlib/filled_contours.ipynb
+++ b/examples/gallery/matplotlib/filled_contours.ipynb
@@ -45,7 +45,9 @@
     "    return lons, lats, data\n",
     "\n",
     "lons, lats, data = sample_data()\n",
-    "contours = gv.FilledContours((lons, lats, data))"
+    "\n",
+    "# Make sure we declare the central longitude\n",
+    "contours = gv.FilledContours((lons, lats, data), crs=ccrs.PlateCarree(central_longitude=180))"
    ]
   },
   {
@@ -61,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "contours.opts(projection=ccrs.Mollweide(), cmap='nipy_spectral') * gf.coastline"
+    "contours.opts(colorbar=True, levels=8, color_levels=10, cmap='nipy_spectral', projection=ccrs.Mollweide()) * gf.coastline"
    ]
   }
  ],

--- a/examples/user_guide/Projections.ipynb
+++ b/examples/user_guide/Projections.ipynb
@@ -174,7 +174,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "features.opts(projection=crs.Orthographic(central_longitude=0, central_latitude=30), global_extent=True)"
+    "features.opts(projection=crs.Orthographic(central_longitude=-90, central_latitude=30), global_extent=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is particularly important when the data is specified in the longitudes of the data are defined in the range 0 to 360 rather than the default -180 to 180. In this case ensure that the ``crs`` of the element declares the actual ``central_longitude``, e.g. 180 degrees rather than the default 0 degrees. Let us draw the same polygon with the default ``crs`` (centered on 0) and a custom ``crs`` centered on 180 degrees:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poly_data = [(180, 0), (270, 45), (360, 0)]\n",
+    "features * gv.Polygons(poly_data) * gv.Polygons(poly_data, crs=crs.PlateCarree(central_longitude=180)).opts(global_extent=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see the default projection wraps the values above 180, while the custom projection automatically translates the polygon by the ``central_longitude``."
    ]
   },
   {

--- a/examples/user_guide/Resampling_Grids.ipynb
+++ b/examples/user_guide/Resampling_Grids.ipynb
@@ -253,8 +253,6 @@
    "outputs": [],
    "source": [
     "ds = xr.tutorial.open_dataset('rasm').load()\n",
-    "# Adjust the longitudes so they are in the range -180 to 180\n",
-    "ds.xc.values[ds.xc.values>180] -= 360 \n",
     "ds"
    ]
   },

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -1,7 +1,6 @@
 import logging
 
 import param
-import shapely
 import numpy as np
 
 from cartopy import crs as ccrs
@@ -64,15 +63,11 @@ class project_path(_project_operation):
                              ' consider using PlateCarree/RotatedPole.')
 
         boundary = Polygon(crs.boundary)
-        bounds = [round(b, 10) for b in boundary.bounds]
-        xoffset = round((boundary.bounds[2]-boundary.bounds[0])/2.)
         if isinstance(element, Polygons):
             geoms = polygons_to_geom_dicts(element, skip_invalid=False)
         else:
             geoms = path_to_geom_dicts(element, skip_invalid=False)
-
         data_bounds = max_extents([g['geometry'].bounds for g in geoms])
-        total_bounds = tuple(round(b, 10) for b in data_bounds)
 
         projected = []
         for path in geoms:
@@ -310,6 +305,10 @@ class project_image(_project_operation):
             else:
                 projected, extents = arr, trgt_ext
             arrays.append(projected)
+
+        if xn == 0 or yn == 0:
+            return img.clone([], bounds=extents, crs=proj)
+
         xunit = ((extents[1]-extents[0])/float(xn))/2.
         yunit = ((extents[3]-extents[2])/float(yn))/2.
         xs = np.linspace(extents[0]+xunit, extents[1]-xunit, xn)

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -6,7 +6,7 @@ import numpy as np
 from cartopy import crs as ccrs
 from cartopy.img_transform import warp_array, _determine_bounds
 from holoviews.core.data import MultiInterface
-from holoviews.core.util import cartesian_product, get_param_values, max_extents, pd
+from holoviews.core.util import cartesian_product, get_param_values, pd
 from holoviews.operation import Operation
 from shapely.geometry import Polygon, MultiPolygon
 from shapely.geometry.collection import GeometryCollection
@@ -62,12 +62,10 @@ class project_path(_project_operation):
                              ' Spherical contouring is not supported - '
                              ' consider using PlateCarree/RotatedPole.')
 
-        boundary = Polygon(crs.boundary)
         if isinstance(element, Polygons):
             geoms = polygons_to_geom_dicts(element, skip_invalid=False)
         else:
             geoms = path_to_geom_dicts(element, skip_invalid=False)
-        data_bounds = max_extents([g['geometry'].bounds for g in geoms])
 
         projected = []
         for path in geoms:

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -28,6 +28,14 @@ def wrap_lons(lons, base, period):
 def project_extents(extents, src_proj, dest_proj, tol=1e-6):
     x1, y1, x2, y2 = extents
 
+    if (isinstance(src_proj, ccrs.PlateCarree) and
+        not isinstance(dest_proj, ccrs.PlateCarree) and
+        src_proj.proj4_params['lon_0'] != 0):
+        xoffset = src_proj.proj4_params['lon_0']
+        x1 = x1 - xoffset
+        x2 = x2 - xoffset
+        src_proj = ccrs.PlateCarree()
+
     # Limit latitudes
     cy1, cy2 = src_proj.y_limits
     if y1 < cy1: y1 = cy1

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ def package_assets(example_path):
 _required = [
     'bokeh >=1.0.0',
     'cartopy >=0.16.0',  # prevents pip alone (requires external package manager)
-    'holoviews >=1.11.0',
+    'holoviews >=1.11.1',
     'numpy >=1.0',
     'param >=1.6.1'
 ]


### PR DESCRIPTION
Previously geoviews used some brittle logic to determine where to wrap longitudes. The correct thing to do instead is let the user declare the central_longitude as part of the ``crs``. This PR ensures the central_longitude is handled correctly and updates docs and examples to make use of this feature.