### PR TITLE
Add geometry resampling operation

### DIFF
--- a/examples/user_guide/Geometries.ipynb
+++ b/examples/user_guide/Geometries.ipynb
@@ -87,7 +87,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Zoom in using the bokeh zoom widget and you should see that the right hand panel is using a higher resultion dataset for the land feature"
+    "Zoom in using the bokeh zoom widget and you should see that the right hand panel is using a higher resolution dataset for the land feature.\n",
+    "\n",
+    "Instead of displaying a ``Feature`` directly it is also possible to request the geometries inside a ``Feature`` using the ``Feature.geoms`` method, which also allows specifying a ``scale`` and a ``bounds`` to select a subregion:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gf.land.geoms('50m', bounds=(-10, 40, 10, 60))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When working interactively with higher resolution datasets it is sometimes necessary to dynamically update the geometries based on the current viewport. The ``resample_geometry`` operation is an efficient way to display only polygons that intersect with the current viewport and downsample polygons on-the-fly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gv.operation.resample_geometry(gf.coastline.geoms('10m')).opts(width=400, height=400, color='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try zooming into the plot above and you will see the coastline geometry resolve to a higher resolution dynamically (this requires a live Python kernel)."
    ]
   },
   {
@@ -105,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "land_geoms = list(gf.land.data.geometries())\n",
+    "land_geoms = gf.land.geoms(as_element=False)\n",
     "land_geoms[21]"
    ]
   },
@@ -216,7 +250,7 @@
     "hv.output(backend='bokeh')\n",
     "\n",
     "gv.Shape.from_records(shapes.records(), referendum, on='code', value='leaveVoteshare',\n",
-    "                     index=['name', 'regionName']).opts(tools=['hover'], width=350, height=500)"
+    "                      index=['name', 'regionName']).opts(tools=['hover'], width=350, height=500)"
    ]
   },
   {

--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -110,7 +110,9 @@ class GeomDictInterface(DictInterface):
         geom_dims = cls.geom_dims(dataset)
         if dim in geom_dims:
             bounds = dataset.data['geometry'].bounds
-            if geom_dims.index(dim) == 0:
+            if not bounds:
+                return np.nan, np.nan
+            elif geom_dims.index(dim) == 0:
                 return bounds[0], bounds[2]
             else:
                 return bounds[1], bounds[3]
@@ -131,7 +133,10 @@ class GeomDictInterface(DictInterface):
         d = dataset.get_dimension(dim)
         geom_dims = cls.geom_dims(dataset)
         if d in geom_dims:
-            array = geom_to_array(dataset.data['geometry'])
+            g = dataset.data['geometry']
+            if not g:
+                return np.array([])
+            array = geom_to_array(g)
             idx = geom_dims.index(d)
             return array[:, idx]
         return DictInterface.values(dataset, dim, expanded, flat)

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -146,17 +146,24 @@ class Feature(_GeoFeature):
         Parameters
         ----------
         scale: str
-           Scale of the geometry to return expressed as string, e.g.
-           '10m', '50m' or '110m'
+          Scale of the geometry to return expressed as string.
+          Available scales depends on the Feature type.
+
+          NaturalEarthFeature:
+           '10m', '50m', '110m'
+
+          GSHHSFeature:
+           'auto', 'coarse', 'low', 'intermediate', 'high', 'full'
+
         bounds: tuple
-           Tuple of a bounding region to query for geometries in
+          Tuple of a bounding region to query for geometries in
         as_element: boolean
-           Whether to wrap the geometries in an element
+          Whether to wrap the geometries in an element
 
         Returns
         -------
         geometries: Polygons/Path
-           Polgons or Path object wrapping around returned geometries
+          Polygons or Path object wrapping around returned geometries
         """
         feature = self.data
         if scale is not None:

--- a/geoviews/operation/__init__.py
+++ b/geoviews/operation/__init__.py
@@ -7,8 +7,8 @@ from ..element import _Element
 from .projection import ( # noqa (API import)
     project_image, project_path, project_shape, project_points,
     project_graph, project_quadmesh, project)
-from .resample import resample_geometry
-from .regrid import weighted_regrid
+from .resample import resample_geometry # noqa (API import)
+from .regrid import weighted_regrid # noqa (API import)
 
 geo_ops = [contours, bivariate_kde]
 try:

--- a/geoviews/operation/__init__.py
+++ b/geoviews/operation/__init__.py
@@ -6,8 +6,9 @@ from .. import element as gv_element
 from ..element import _Element
 from .projection import ( # noqa (API import)
     project_image, project_path, project_shape, project_points,
-    project_graph, project_quadmesh, project
-)
+    project_graph, project_quadmesh, project)
+from .resample import resample_geometry
+from .regrid import weighted_regrid
 
 geo_ops = [contours, bivariate_kde]
 try:

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -1,0 +1,191 @@
+import param
+import numpy as np
+
+from holoviews import Polygons, Path
+from holoviews.streams import RangeXY
+from holoviews import Operation
+from shapely.geometry import Polygon
+from shapely.strtree import STRtree
+
+from ..util import polygons_to_geom_dicts, path_to_geom_dicts
+
+
+def find_geom(geom, geoms):
+    """
+    Returns the index of a geometry in a list of geometries avoiding
+    expensive equality checks of `in` operator.
+    """
+    for i, g in enumerate(geoms):
+        if g is geom:
+            return i
+
+def compute_zoom_level(bounds, domain, levels):
+    """
+    Computes a zoom level given a bounds polygon, a polygon of the
+    overall domain and the number of zoom levels to divide the data
+    into.
+
+    Parameters
+    ----------
+    bounds: shapely.geometry.Polygon
+        Polygon representing the area of the current viewport
+    domain: shapely.geometry.Polygon
+        Polygon representing the overall bounding region of the data
+    levels: int
+        Number of zoom levels to divide the domain into
+
+    Returns
+    -------
+    zoom_level: int
+        Integer zoom level
+    """
+    area_fraction = min(bounds.area/domain.area, 1)
+    return int(min(round(np.log2(1/area_fraction)), levels))
+
+
+def bounds_to_poly(bounds):
+    """
+    Constructs a shapely Polygon from the provided bounds tuple.
+
+    Parameters
+    ----------
+    bounds: tuple
+        Tuple representing the (left, bottom, right, top) coordinates
+
+    Returns
+    -------
+    polygon: shapely.geometry.Polygon
+        Shapely Polygon geometry of the bounds
+    """
+    x0, y0, x1, y1 = bounds
+    return Polygon([(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
+
+
+class resample_geometry(Operation):
+    """
+    This operation dynamically culls and resamples Path or Polygons
+    elements based on the current zoom level. On first execution a
+    RTree created usng the Sort-Tile-Recursive algorithm, which is
+    used to query for geometries within the current viewport (defined
+    by the x_range and y_range).
+
+    Any geometries returned by the RTree query are tested to ensure
+    their area is over the display_threshold expressed as a fraction
+    of the current viewport area. Any remaining polygons are
+    simplified using the Douglas-Peucker algorithm, which eliminates
+    vertices while ensuring that the curve does not diverge from the
+    original curve by more than the tolerance. The tolerance is
+    expressed as a fraction of the square root of the area of the
+    current viewport.
+
+    Once computed a simplified geometry is cached depending on the
+    current zoom level. The number of valid zoom levels can be
+    declared and are used to recursively subdivide the domain into
+    smaller subregions. 
+    """
+
+    clip = param.Boolean(default=False, doc="""
+        Whether to disable the cache and clip polygons
+        to current bounds.""")
+
+    zoom_levels = param.Integer(default=20, doc="""
+        The number of zoom levels to cache.""")
+
+    dynamic = param.Boolean(default=True, doc="""
+       Enables dynamic processing by default.""")
+
+    tolerance_factor = param.Number(default=0.005, doc="""
+        The tolerance distance for path simplification as a fraction
+        of the square root of the area of the current viewport.""")
+
+    display_threshold = param.Number(default=0.0001, doc="""
+        The fraction of the current viewport covered by a geometry
+        before it is shown.""")
+
+    preserve_topology = param.Boolean(default=False, doc="""
+        Whether to preserve topology between geometries
+        (much faster when disabled).""")
+
+    streams = param.List(default=[RangeXY], doc="""
+        List of streams that are applied if dynamic=True, allowing
+        for dynamic interaction with the plot.""")
+
+    x_range  = param.NumericTuple(default=None, length=2, doc="""
+       The x_range as a tuple of min and max x-value. Auto-ranges
+       if set to None.""")
+
+    y_range  = param.NumericTuple(default=None, length=2, doc="""
+       The x_range as a tuple of min and max y-value. Auto-ranges
+       if set to None.""")
+
+    @param.parameterized.bothmethod
+    def instance(self_or_cls,**params):
+        inst = super(resample_geometry, self_or_cls).instance(**params)
+        inst._cache = {}
+        return inst
+
+    def _process(self, element, key=None):
+        # Compute view port
+        x0, x1 = self.p.x_range or element.range(0)
+        y0, y1 = self.p.y_range or element.range(1)
+        bounds = bounds_to_poly((x0, y0, x1, y1))
+
+        # Initialize or lookup cache with STRTree 
+        if element._plot_id in self._cache:
+            cache = self._cache[element._plot_id]
+            domain, tree, geom_dicts, geom_cache, area_cache = cache
+        else:
+            if isinstance(element, Polygons):
+                geom_dicts = polygons_to_geom_dicts(element)
+            elif isinstance(element, Path):
+                geom_dicts = path_to_geom_dicts(element)
+            geoms = [g['geometry'] for g in geom_dicts]
+            tree = STRtree(geoms)
+            domain = bounds
+            geom_cache, area_cache = {}, {}
+            self._cache.clear()
+            cache = (domain, tree, geom_dicts, geom_cache, area_cache)
+            self._cache[element._plot_id] = cache
+
+        area = bounds.area
+        current_zoom = compute_zoom_level(bounds, domain, self.p.zoom_levels)
+        tol = np.sqrt(bounds.area) * self.p.tolerance_factor
+
+        # Query RTree, then cull and simplify polygons
+        new_geoms, gdict = [], {}
+        for g in tree.query(bounds):
+            garea = area_cache.get(id(g))
+            if garea is None:
+                is_poly = 'Polygon' in g.geom_type
+                garea = g.area if is_poly else bounds_to_poly(g.bounds).area
+                area_cache[id(g)] = garea
+
+            # Skip if geometry area is below display threshold or
+            # does not intersect with viewport
+            if ((self.p.display_threshold is not None and
+                 (garea/area) < self.p.display_threshold)
+                or not g.intersects(bounds)):
+                continue
+
+            # Try to look up geometry in cache by zoom level
+            cache_id = (id(g), current_zoom)
+            if cache_id in geom_cache and not self.p.clip:
+                geom_dict = geom_cache[cache_id]
+            else:
+                if element.vdims:
+                    gidx = find_geom(tree._geoms, g)
+                    gdict = geom_dicts[gidx]
+
+                cache = True
+                if self.p.clip:
+                    cache = False # Do not cache when clipping
+                    g = g.intersection(bounds)
+
+                g = g.simplify(tol, self.p.preserve_topology)
+                if not g:
+                    continue # Skip if geometry empty
+                geom_dict = dict(gdict, geometry=g)
+                if cache:
+                    geom_cache[cache_id] = geom_dict
+            new_geoms.append(geom_dict)
+        return element.clone(new_geoms)

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -65,12 +65,12 @@ class resample_geometry(Operation):
     """
     This operation dynamically culls and resamples Path or Polygons
     elements based on the current zoom level. On first execution a
-    RTree created usng the Sort-Tile-Recursive algorithm, which is
+    RTree created using the Sort-Tile-Recursive algorithm, which is
     used to query for geometries within the current viewport (defined
     by the x_range and y_range).
 
     Any geometries returned by the RTree query are tested to ensure
-    their area is over the display_threshold expressed as a fraction
+    their area is over the display_threshold, expressed as a fraction
     of the current viewport area. Any remaining polygons are
     simplified using the Douglas-Peucker algorithm, which eliminates
     vertices while ensuring that the curve does not diverge from the

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -104,14 +104,15 @@ class resample_geometry(Operation):
        Enables dynamic processing by default.""")
 
     preserve_topology = param.Boolean(default=False, doc="""
-        Whether to preserve topology between geometries
-        (much faster when disabled).""")
+        Whether to preserve topology between geometries. If disabled
+        simplification can produce self-intersecting or otherwise
+        invalid geometries but will be much faster.""")
 
     streams = param.List(default=[RangeXY], doc="""
         List of streams that are applied if dynamic=True, allowing
         for dynamic interaction with the plot.""")
 
-    tolerance_factor = param.Number(default=0.005, doc="""
+    tolerance_factor = param.Number(default=0.002, doc="""
         The tolerance distance for path simplification as a fraction
         of the square root of the area of the current viewport.""")
 

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -65,7 +65,7 @@ class resample_geometry(Operation):
     """
     This operation dynamically culls and resamples Path or Polygons
     elements based on the current zoom level. On first execution a
-    RTree created using the Sort-Tile-Recursive algorithm, which is
+    RTree is created using the Sort-Tile-Recursive algorithm, which is
     used to query for geometries within the current viewport (defined
     by the x_range and y_range).
 

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -219,7 +219,9 @@ def polygons_to_geom_dicts(polygons, skip_invalid=True):
             if j != (len(arrays)-1):
                 arr = arr[:-1] # Drop nan
 
-            if len(arr) == 1:
+            if len(arr) == 0:
+                continue
+            elif len(arr) == 1:
                 if skip_invalid:
                     continue
                 poly = Point(arr[0])
@@ -273,8 +275,10 @@ def path_to_geom_dicts(path, skip_invalid=True):
         for j, arr in enumerate(arrays):
             if j != (len(arrays)-1):
                 arr = arr[:-1] # Drop nan
-            
-            if len(arr) == 1:
+
+            if len(arr) == 0:
+                continue
+            elif len(arr) == 1:
                 if skip_invalid:
                     continue
                 g = Point(arr[0])
@@ -341,8 +345,11 @@ def geom_to_array(geom):
     if geom.geom_type == 'Point':
         return np.array([[geom.x, geom.y]])
     if hasattr(geom, 'exterior'):
-        xs = np.array(geom.exterior.coords.xy[0])
-        ys = np.array(geom.exterior.coords.xy[1])
+        if geom.exterior is None:
+            xs, ys = np.array([]), np.array([])
+        else:
+            xs = np.array(geom.exterior.coords.xy[0])
+            ys = np.array(geom.exterior.coords.xy[1])
     elif geom.geom_type in ('LineString', 'LinearRing'):
         arr = geom_to_arr(geom)
         return arr
@@ -556,8 +563,8 @@ def load_tiff(filename, crs=None, apply_transform=False, nan_nodata=False, **kwa
     a cartopy projection otherwise it will default to a non-geographic
     HoloViews element.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     filename: string
        Filename pointing to geotiff file to load
     crs: Cartopy CRS or EPSG string (optional)
@@ -572,7 +579,6 @@ def load_tiff(filename, crs=None, apply_transform=False, nan_nodata=False, **kwa
     Returns
     -------
     element: Image/RGB/QuadMesh element
-
     """
     try:
         import xarray as xr
@@ -594,8 +600,8 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
     attempt to decode it into a cartopy projection otherwise it
     will default to a non-geographic HoloViews element.
 
-    Arguments
-    ---------
+    Parameters
+    ----------
     da: xarray.DataArray
        DataArray to convert to element
     crs: Cartopy CRS or EPSG string (optional)


### PR DESCRIPTION
This operation makes it possible to dynamically work with relatively large geometry datasets. The ``resample_geometry`` operation is similar to other resampling operations such as ``rasterize``, ``regrid`` and ``decimate`` in that it progressively adjusts the detail of the input element as you zoom in and out of a plot. I'll let the docstring explain how it works:

```
    This operation dynamically culls and resamples Path or Polygons
    elements based on the current zoom level. On first execution a
    RTree created using the Sort-Tile-Recursive algorithm, which is
    used to query for geometries within the current viewport (defined
    by the x_range and y_range).

    Any geometries returned by the RTree query are tested to ensure
    their area is over the display_threshold, expressed as a fraction
    of the current viewport area. Any remaining polygons are
    simplified using the Douglas-Peucker algorithm, which eliminates
    vertices while ensuring that the curve does not diverge from the
    original curve by more than the tolerance. The tolerance is
    expressed as a fraction of the square root of the area of the
    current viewport. 

    Once computed a simplified geometry is cached depending on the
    current zoom level. The number of valid zoom levels can be
    declared and are used to recursively subdivide the domain into
    smaller subregions.

    If requested the geometries can also be clipped to the current
    viewport which avoids having to render vertices that are not
    visible.
```

(See the [wikipedia entry](https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm) for more details).

As a simple example here is the operation applied to the land geometry feature:

```python
resample_geometry(gf.land.geoms('50m')).opts(width=600, height=300, projection=ccrs.PlateCarree())
````

![land_world](https://user-images.githubusercontent.com/1550771/51395346-8c715e00-1b34-11e9-9a15-749de54dc1c5.gif)

```python
resample_geometry(gf.coastline.geoms('10m')).opts(width=600, height=300, projection=ccrs.PlateCarree())
```

![coastlines](https://user-images.githubusercontent.com/1550771/51399760-9d26d180-1b3e-11e9-8cd1-664f8da8576c.gif)
