### PR TITLE
Matplotlib axis has no property gridlines (bugfix)

### DIFF
--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -108,7 +108,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         ret = super(GeoPlot, self)._finalize_axis(*args, **kwargs)
         axis = self.handles['axis']
         if self.show_grid:
-            axis.gridlines()
+            axis.grid()
         if self.global_extent:
             axis.set_global()
         return ret


### PR DESCRIPTION
Self-explanatory. Unsure if this used to be part of the matplotlib API, but `.gridlines()` is definitely not the way to set axis grids now.