### PR TITLE
Hardcode the OSM tile source to https

### DIFF
--- a/geoviews/tile_sources.py
+++ b/geoviews/tile_sources.py
@@ -84,7 +84,7 @@ ESRI = EsriImagery # For backwards compatibility with gv 1.5
 
 
 # Miscellaneous
-OSM = WMTS('http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")
+OSM = WMTS('https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png', name="OSM")
 Wikipedia = WMTS('https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png', name="Wikipedia")
 
 


### PR DESCRIPTION
At the moment my dashboard loads openstreetmap.org resources via HTTP then get redirected to HTTPS. This PR changes the default to HTTPS for speed and security.

I have tried converting the other non-HTTPS tile sources to HTTPS but they would trigger "This Connection is Untrusted" messages in the browser when individual tiles were tested.