### PR TITLE
Removed unused imports

### DIFF
--- a/examples/gallery/bokeh/city_populations_2050.ipynb
+++ b/examples/gallery/bokeh/city_populations_2050.ipynb
@@ -10,8 +10,6 @@
     "import geoviews as gv\n",
     "import geoviews.tile_sources as gvts\n",
     "\n",
-    "from geoviews import dim\n",
-    "\n",
     "gv.extension('bokeh')"
    ]
   },

--- a/examples/gallery/bokeh/filled_contours.ipynb
+++ b/examples/gallery/bokeh/filled_contours.ipynb
@@ -7,7 +7,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import holoviews as hv\n",
     "import geoviews as gv\n",
     "import geoviews.feature as gf\n",
     "\n",

--- a/examples/user_guide/Geometries.ipynb
+++ b/examples/user_guide/Geometries.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import pandas as pd\n",
     "import holoviews as hv\n",
-    "import numpy as np\n",
     "import geoviews as gv\n",
     "import geoviews.feature as gf\n",
     "import cartopy\n",


### PR DESCRIPTION
```
(nbsdev) D:\code\ioam\geoviews>pytest -v --nbsmoke-lint --nbsmoke-lint-debug examples
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.4.1, py-1.8.0, pluggy-0.9.0 -- d:\venvs\nbsdev\scripts\python.exe
cachedir: .pytest_cache
rootdir: D:\code\ioam\geoviews, inifile: tox.ini
plugins: cov-2.7.1, nbsmoke-0.2.8.post44+gbdfd485
collected 35 items / 68 skipped

examples/Homepage.ipynb::D:\code\ioam\geoviews\examples\Homepage.ipynb PASSED                                                                 [  2%]
examples/gallery/bokeh/airport_graph.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\airport_graph.ipynb PASSED                           [  5%]
examples/gallery/bokeh/brexit_choropleth.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\brexit_choropleth.ipynb PASSED                   [  8%]
examples/gallery/bokeh/city_populations_2050.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\city_populations_2050.ipynb FAILED           [ 11%]
examples/gallery/bokeh/filled_contours.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\filled_contours.ipynb FAILED                       [ 14%]
examples/gallery/bokeh/great_circle.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\great_circle.ipynb PASSED                             [ 17%]
examples/gallery/bokeh/katrina_track.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\katrina_track.ipynb PASSED                           [ 20%]
examples/gallery/bokeh/new_york_boroughs.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\new_york_boroughs.ipynb PASSED                   [ 22%]
examples/gallery/bokeh/orthographic_vectorfield.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\orthographic_vectorfield.ipynb PASSED     [ 25%]
examples/gallery/bokeh/tile_sources.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\tile_sources.ipynb PASSED                             [ 28%]
examples/gallery/bokeh/trimesh_uk.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\trimesh_uk.ipynb PASSED                                 [ 31%]
examples/gallery/bokeh/vectorfield_example.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\vectorfield_example.ipynb PASSED               [ 34%]
examples/gallery/bokeh/world_population.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\world_population.ipynb PASSED                     [ 37%]
examples/gallery/bokeh/xarray_image.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\xarray_image.ipynb PASSED                             [ 40%]
examples/gallery/bokeh/xarray_quadmesh.ipynb::D:\code\ioam\geoviews\examples\gallery\bokeh\xarray_quadmesh.ipynb PASSED                       [ 42%]
examples/gallery/matplotlib/airport_graph.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\airport_graph.ipynb PASSED                 [ 45%]
examples/gallery/matplotlib/brexit_choropleth.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\brexit_choropleth.ipynb PASSED         [ 48%]
examples/gallery/matplotlib/city_population.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\city_population.ipynb PASSED             [ 51%]
examples/gallery/matplotlib/filled_contours.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\filled_contours.ipynb PASSED             [ 54%]
examples/gallery/matplotlib/great_circle.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\great_circle.ipynb PASSED                   [ 57%]
examples/gallery/matplotlib/katrina_track.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\katrina_track.ipynb PASSED                 [ 60%]
examples/gallery/matplotlib/new_york_boroughs.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\new_york_boroughs.ipynb PASSED         [ 62%]
examples/gallery/matplotlib/orthographic_vectorfield.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\orthographic_vectorfield.ipynb PASSED [ 65%]
examples/gallery/matplotlib/tile_sources.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\tile_sources.ipynb PASSED                   [ 68%]
examples/gallery/matplotlib/trimesh_uk.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\trimesh_uk.ipynb PASSED                       [ 71%]
examples/gallery/matplotlib/vectorfield_example.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\vectorfield_example.ipynb PASSED     [ 74%]
examples/gallery/matplotlib/world_population.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\world_population.ipynb PASSED           [ 77%]
examples/gallery/matplotlib/xarray_image.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\xarray_image.ipynb PASSED                   [ 80%]
examples/gallery/matplotlib/xarray_quadmesh.ipynb::D:\code\ioam\geoviews\examples\gallery\matplotlib\xarray_quadmesh.ipynb PASSED             [ 82%]
examples/user_guide/Geometries.ipynb::D:\code\ioam\geoviews\examples\user_guide\Geometries.ipynb FAILED                                       [ 85%]
examples/user_guide/Gridded_Datasets_I.ipynb::D:\code\ioam\geoviews\examples\user_guide\Gridded_Datasets_I.ipynb PASSED                       [ 88%]
examples/user_guide/Gridded_Datasets_II.ipynb::D:\code\ioam\geoviews\examples\user_guide\Gridded_Datasets_II.ipynb PASSED                     [ 91%]
examples/user_guide/Projections.ipynb::D:\code\ioam\geoviews\examples\user_guide\Projections.ipynb PASSED                                     [ 94%]
examples/user_guide/Resampling_Grids.ipynb::D:\code\ioam\geoviews\examples\user_guide\Resampling_Grids.ipynb PASSED                           [ 97%]
examples/user_guide/Working_with_Bokeh.ipynb::D:\code\ioam\geoviews\examples\user_guide\Working_with_Bokeh.ipynb PASSED                       [100%]

===================================================================== FAILURES =====================================================================
___________________________________________________________________ test session ___________________________________________________________________
D:\code\ioam\geoviews\examples\gallery\bokeh\city_populations_2050.ipynb
** line 18 col 0: 'geoviews.dim' imported but unused
To see python source that was checked by pyflakes: D:\code\ioam\geoviews\examples\gallery\bokeh\city_populations_2050.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\ioam\geoviews\examples\gallery\bokeh\city_populations_2050.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\ioam\geoviews\examples\gallery\bokeh\filled_contours.ipynb
** line 15 col 0: 'holoviews as hv' imported but unused
To see python source that was checked by pyflakes: D:\code\ioam\geoviews\examples\gallery\bokeh\filled_contours.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\ioam\geoviews\examples\gallery\bokeh\filled_contours.nbsmoke-debug-premagicprocess.py
___________________________________________________________________ test session ___________________________________________________________________
D:\code\ioam\geoviews\examples\user_guide\Geometries.ipynb
** line 16 col 0: 'numpy as np' imported but unused
To see python source that was checked by pyflakes: D:\code\ioam\geoviews\examples\user_guide\Geometries.nbsmoke-debug-postmagicprocess.py
To see python source before magics were handled by nbsmoke: D:\code\ioam\geoviews\examples\user_guide\Geometries.nbsmoke-debug-premagicprocess.py
================================================= 3 failed, 32 passed, 68 skipped in 74.74 seconds =================================================
```